### PR TITLE
feat(auth): replace plaintext passwords with hashed credentials

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -33,3 +33,18 @@ For GitHub Actions deployment, `js/config.js` is generated during deploy from re
 - `JOIN_APP_FIREBASE_TASKS_ID`
 - `JOIN_APP_FIREBASE_USERS_ID`
 - optional: `JOIN_APP_STORAGE_URL`
+
+## Password handling
+
+- New accounts store `passwordHash`, `passwordSalt`, `passwordHashIterations`, `passwordHashVersion`.
+- Plaintext `password` is no longer written for signup or contact creation.
+- During login, legacy users with plaintext `password` are migrated to hashed credentials and persisted.
+
+### Basic abuse checks
+
+1. Create a user, then inspect Firebase user JSON.
+   Expected: no plaintext `password` field.
+2. Try login with wrong password.
+   Expected: login is rejected with invalid credentials message.
+3. Create a new contact and inspect stored contact JSON.
+   Expected: no predictable/default password is added.

--- a/addTask.html
+++ b/addTask.html
@@ -27,6 +27,7 @@
   <script src="js/helper.js"></script>
   <script src="js/config.js"></script>
   <script src="js/storage.js"></script>
+  <script src="js/auth.js"></script>
   <script src="assets/templates/html_templates.js"></script>
   <script src="js/filepicker.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/viewerjs/1.11.7/viewer.min.js" 

--- a/board.html
+++ b/board.html
@@ -24,6 +24,7 @@
     <script src="./js/addTask_tasks.js"></script>
     <script src="./js/config.js"></script>
     <script src="./js/storage.js"></script>
+    <script src="./js/auth.js"></script>
     <script src="./js/helper.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/viewerjs/1.11.7/viewer.min.js" integrity="sha512-lZD0JiwhtP4UkFD1mc96NiTZ14L7MjyX5Khk8PMxJszXMLvu7kjq1sp4bb0tcL6MY+/4sIuiUxubOqoueHrW4w==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 

--- a/contacts.html
+++ b/contacts.html
@@ -14,6 +14,7 @@
     <link rel="stylesheet" href="./assets/css/board.css">
     <script src="./js/config.js"></script>
     <script src="./js/storage.js"></script>
+    <script src="./js/auth.js"></script>
     <script src="./js/addTask.js"></script>
     <script src="./js/contacts_render.js"></script>
     <script src="./js/contacts.js"></script>

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
     <script src="script.js"></script>
     <script src="./js/config.js"></script>
     <script src="./js/storage.js"></script>
+    <script src="./js/auth.js"></script>
     <script src="./js/contacts.js"></script>
     <script src="./js/summary.js"></script>
     <script src="./js/signUp.js"></script>

--- a/js/auth.js
+++ b/js/auth.js
@@ -1,0 +1,193 @@
+const PASSWORD_HASH_CONFIG = Object.freeze({
+    algorithm: "PBKDF2",
+    hash: "SHA-256",
+    iterations: 120000,
+    keyLengthBits: 256,
+    saltLengthBytes: 16,
+    version: "pbkdf2-sha256-v1",
+});
+
+function getWebCryptoOrThrow() {
+    if (typeof window !== "undefined" && window.crypto && window.crypto.subtle) {
+        return window.crypto;
+    }
+    throw new Error("Web Crypto API is not available in this browser.");
+}
+
+function bytesToHex(bytes) {
+    return Array.from(bytes)
+        .map((byte) => byte.toString(16).padStart(2, "0"))
+        .join("");
+}
+
+function hexToBytes(hexString) {
+    if (typeof hexString !== "string" || hexString.length % 2 !== 0) {
+        throw new Error("Invalid hex string.");
+    }
+
+    const bytes = new Uint8Array(hexString.length / 2);
+    for (let i = 0; i < hexString.length; i += 2) {
+        bytes[i / 2] = parseInt(hexString.slice(i, i + 2), 16);
+    }
+    return bytes;
+}
+
+function timingSafeEqual(a, b) {
+    if (typeof a !== "string" || typeof b !== "string") {
+        return false;
+    }
+    if (a.length !== b.length) {
+        return false;
+    }
+
+    let mismatch = 0;
+    for (let i = 0; i < a.length; i++) {
+        mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+    }
+    return mismatch === 0;
+}
+
+function normalizeAuthEmail(email) {
+    if (typeof email !== "string") {
+        return "";
+    }
+    return email.trim().toLowerCase();
+}
+
+async function derivePasswordHash(password, saltHex, iterations) {
+    if (typeof password !== "string" || password.length === 0) {
+        throw new Error("Password must be a non-empty string.");
+    }
+
+    const cryptoApi = getWebCryptoOrThrow();
+    const encoder = new TextEncoder();
+    const keyMaterial = await cryptoApi.subtle.importKey(
+        "raw",
+        encoder.encode(password),
+        PASSWORD_HASH_CONFIG.algorithm,
+        false,
+        ["deriveBits"]
+    );
+
+    const derivedBits = await cryptoApi.subtle.deriveBits(
+        {
+            name: PASSWORD_HASH_CONFIG.algorithm,
+            salt: hexToBytes(saltHex),
+            iterations,
+            hash: PASSWORD_HASH_CONFIG.hash,
+        },
+        keyMaterial,
+        PASSWORD_HASH_CONFIG.keyLengthBits
+    );
+
+    return bytesToHex(new Uint8Array(derivedBits));
+}
+
+async function createPasswordCredentials(plainPassword) {
+    const cryptoApi = getWebCryptoOrThrow();
+    const saltBytes = cryptoApi.getRandomValues(
+        new Uint8Array(PASSWORD_HASH_CONFIG.saltLengthBytes)
+    );
+    const passwordSalt = bytesToHex(saltBytes);
+    const passwordHash = await derivePasswordHash(
+        plainPassword,
+        passwordSalt,
+        PASSWORD_HASH_CONFIG.iterations
+    );
+
+    return {
+        passwordHash,
+        passwordSalt,
+        passwordHashIterations: PASSWORD_HASH_CONFIG.iterations,
+        passwordHashVersion: PASSWORD_HASH_CONFIG.version,
+    };
+}
+
+function isLegacyPlaintextPasswordUser(user) {
+    return (
+        user &&
+        typeof user === "object" &&
+        typeof user.password === "string" &&
+        user.password.length > 0 &&
+        (!user.passwordHash || typeof user.passwordHash !== "string")
+    );
+}
+
+function hasSecurePasswordCredentials(user) {
+    return (
+        user &&
+        typeof user.passwordHash === "string" &&
+        user.passwordHash.length > 0 &&
+        typeof user.passwordSalt === "string" &&
+        user.passwordSalt.length > 0
+    );
+}
+
+function normalizePasswordMetadata(user) {
+    if (!hasSecurePasswordCredentials(user)) {
+        return false;
+    }
+
+    let changed = false;
+
+    if (
+        typeof user.passwordHashIterations !== "number" ||
+        !Number.isInteger(user.passwordHashIterations) ||
+        user.passwordHashIterations <= 0
+    ) {
+        user.passwordHashIterations = PASSWORD_HASH_CONFIG.iterations;
+        changed = true;
+    }
+
+    if (typeof user.passwordHashVersion !== "string" || user.passwordHashVersion.length === 0) {
+        user.passwordHashVersion = PASSWORD_HASH_CONFIG.version;
+        changed = true;
+    }
+
+    return changed;
+}
+
+async function migrateLegacyPlaintextPasswords(users) {
+    if (!Array.isArray(users)) {
+        return { changed: false };
+    }
+
+    let changed = false;
+
+    for (const user of users) {
+        if (isLegacyPlaintextPasswordUser(user)) {
+            const credentials = await createPasswordCredentials(user.password);
+            delete user.password;
+            Object.assign(user, credentials);
+            changed = true;
+            continue;
+        }
+
+        if (normalizePasswordMetadata(user)) {
+            changed = true;
+        }
+    }
+
+    return { changed };
+}
+
+async function verifyPasswordCredentials(user, plainPassword) {
+    if (!hasSecurePasswordCredentials(user)) {
+        return false;
+    }
+
+    const iterations =
+        typeof user.passwordHashIterations === "number" &&
+        Number.isInteger(user.passwordHashIterations) &&
+        user.passwordHashIterations > 0
+            ? user.passwordHashIterations
+            : PASSWORD_HASH_CONFIG.iterations;
+
+    const candidateHash = await derivePasswordHash(
+        plainPassword,
+        user.passwordSalt,
+        iterations
+    );
+
+    return timingSafeEqual(user.passwordHash, candidateHash);
+}

--- a/js/contact_popups.js
+++ b/js/contact_popups.js
@@ -14,7 +14,6 @@ async function saveContact() {
         mail: contactMail.value,
         phone: contactPhone.value,
         contactColor: generateRandomColor(),
-        password: getFirstNameForDefaultPassword(contactName.value),
       });
 
       await firebaseUpdateItem(users, FIREBASE_USERS_ID);

--- a/js/contacts.js
+++ b/js/contacts.js
@@ -88,17 +88,6 @@ function getNextId(contactsArray) {
 
 
 /**
- * Returns the first name from a given full name string for use as a default password.
- *
- * @param {string} name - The full name string.
- * @return {string} The first name extracted from the full name string.
- */
-function getFirstNameForDefaultPassword(name) {
-  return name.split(" ")[0];
-}
-
-
-/**
  * Finds the maximum id in the contactsArray and returns the next id.
  */
 function getNextId(contactsArray) {

--- a/signUp.html
+++ b/signUp.html
@@ -11,6 +11,7 @@
   <script src="script.js"></script>
   <script src="./js/config.js"></script>
   <script src="./js/storage.js"></script>
+  <script src="./js/auth.js"></script>
   <script src="./js/signUp.js"></script>
   <script src="./js/helper.js"></script>
   <title>Join - Sign Up</title>

--- a/summary.html
+++ b/summary.html
@@ -15,6 +15,7 @@
     <script src="./assets/templates/html_templates.js"></script>
     <script src="./js/config.js"></script>
     <script src="./js/storage.js"></script>
+    <script src="./js/auth.js"></script>
     <script src="./js/contacts.js"></script>
     <script src="./js/board.js"></script>
     <script src="./js/summary.js"></script>


### PR DESCRIPTION
## Goal
This PR addresses the security ticket for password handling and removes plaintext credential handling from the frontend flow.

Closes #2

## What changed
- Added a new auth utility (`js/auth.js`)
  - Password hashing using `PBKDF2 + SHA-256 + salt`
  - Hash-based password verification (no plaintext comparison)
  - Legacy migration for existing users that still have a `password` field
- Updated login flow
  - Removed `user.password === inputPassword` logic
  - Login now validates credentials via stored hash data only
- Updated signup flow
  - New users now store only:
    - `passwordHash`
    - `passwordSalt`
    - `passwordHashIterations`
    - `passwordHashVersion`
  - Email is normalized (`trim + lowercase`)
- Hardened contact creation
  - Removed predictable default password assignment for new contacts
- Added `auth.js` script include to relevant pages
- Extended docs in `CONFIGURATION.md` including basic abuse checks

## Security impact
- Plaintext passwords are no longer written for new users.
- Frontend login no longer compares plaintext passwords.
- Legacy plaintext password records are migrated to hashed credentials during login.

## Validation
- `node --check` passed for all `js/*.js` files and `script.js`.
- Manual checks to run:
  1. Signup: verify new Firebase user records do not contain a plaintext `password` field.
  2. Login: verify wrong password is rejected.
  3. Contact creation: verify no default/predictable password is stored.

## Note
This significantly hardens the current frontend-based setup.  
A full server-side authentication flow (session/token validation on backend) is still the recommended next step.
