### PR TITLE
fix(storage): guard firebase read null/error states

### DIFF
--- a/js/addTask_tasks.js
+++ b/js/addTask_tasks.js
@@ -129,7 +129,10 @@ function clearFormular(){
  * @return {Promise<void>} A Promise that resolves once the task is created.
  */
 async function createTask(){
-    await loadTasksFromRemoteStorage();
+    const loadResult = await loadTasksFromRemoteStorage();
+    if (loadResult.error) {
+        return;
+    }
     collectInformationsForNewCard();
     newTask.images = allImages.map(image => image.base64);
     tasks.push(newTask);
@@ -176,11 +179,16 @@ async function saveTasksToRemoteStorage(){
 *
 */
 async function loadTasksFromRemoteStorage(){
-   tasks = await firebaseGetItem(FIREBASE_TASKS_ID);
+   const loadResult = await firebaseGetArraySafe(FIREBASE_TASKS_ID, {
+      context: 'tasks',
+      errorMessage: 'Could not load tasks. Please try again.',
+   });
+   tasks = loadResult.data;
    tasks.forEach(task => {
        if(!task.hasOwnProperty('subtasks')) task.subtasks = []; 
        if(!task.hasOwnProperty('assignedTo')) task.assignedTo = [];
    })
+   return loadResult;
 }
 
 

--- a/js/board.js
+++ b/js/board.js
@@ -327,7 +327,10 @@ function renderEditCardAssignedContacts(){
  */
 async function saveEditedTask(taskId) {
     console.log("saveEditedTask: Speichern gestartet für Task:", taskId);
-    await loadTasksFromRemoteStorage();
+    const loadResult = await loadTasksFromRemoteStorage();
+    if (loadResult.error) {
+        return;
+    }
     collectInformationsForNewCard();
 
     let taskToSaveIndex = findTaskIndex(taskId);

--- a/js/contact_popups.js
+++ b/js/contact_popups.js
@@ -2,7 +2,13 @@
  * Saves a contact by pushing it to the contacts array and storing it in local storage.
  */
 async function saveContact() {
-  await getContactsFromRemoteStorage();
+  const loadResult = await getContactsFromRemoteStorage({
+    errorMessage: "Could not load contacts. Contact was not created.",
+  });
+  if (loadResult.error) {
+    return;
+  }
+
   if (checkMailExist(document.getElementById("contactMail").value)) {
   } else {
     try {
@@ -21,11 +27,13 @@ async function saveContact() {
       users = [];
       resetContactForm();
       closeOverlay("addContact");
+      displaySuccessMessage("Contact successfully created");
+      loadContacts();
     } catch (error) {
       console.error("Error saving contact:", error);
+      showGlobalUserMessage("Could not save contact. Please try again.");
+      createBtn.disabled = false;
     }
-    displaySuccessMessage("Contact successfully created");
-    loadContacts();
   }
 }
 
@@ -231,7 +239,15 @@ function editContact(id) {
  * @return {undefined} This function does not return a value.
  */
 async function saveEditedContact(id) {
-  let users = await firebaseGetItem(FIREBASE_USERS_ID);
+  const loadResult = await firebaseGetArraySafe(FIREBASE_USERS_ID, {
+    context: "contacts",
+    errorMessage: "Could not load contacts for editing. Please try again.",
+  });
+  if (loadResult.error) {
+    return;
+  }
+
+  let users = loadResult.data;
   const userIndex = users.findIndex((contact) => contact.id === id);
 
   if (userIndex !== -1) {
@@ -296,7 +312,15 @@ function deleteContactFromLocalStorage(contactId) {
  * @return {Promise<void>} A promise that resolves when the contact is successfully deleted.
  */
 async function deleteContact(id) {
-  let users = await firebaseGetItem(FIREBASE_USERS_ID);
+  const loadResult = await firebaseGetArraySafe(FIREBASE_USERS_ID, {
+    context: "contacts",
+    errorMessage: "Could not load contacts for deleting. Please try again.",
+  });
+  if (loadResult.error) {
+    return;
+  }
+
+  let users = loadResult.data;
   const userIndex = users.findIndex((user) => user.id === id);
   if (userIndex !== -1) {
     users.splice(userIndex, 1);

--- a/js/contacts.js
+++ b/js/contacts.js
@@ -8,12 +8,14 @@ let currentContactId = null;
  *
  * @return {Promise<Array>} A promise that resolves to an array of contacts.
  */
-async function getContactsFromRemoteStorage() {
-  try {
-    users = await firebaseGetItem(FIREBASE_USERS_ID);
-  } catch (error) {
-    console.error("Loading error:", error);
-  }
+async function getContactsFromRemoteStorage(options = {}) {
+  const loadResult = await firebaseGetArraySafe(FIREBASE_USERS_ID, {
+    context: "contacts",
+    errorMessage: "Could not load contacts. Please try again.",
+    ...options,
+  });
+  users = loadResult.data;
+  return loadResult;
 }
 
 
@@ -55,8 +57,9 @@ function sortContactsByName(contacts) {
  * @return {Array} An array of contacts sorted by name.
  */
 function getContactsOutOfUsers() {
+  const sourceUsers = Array.isArray(users) ? users : [];
   temp_contacts = [];
-  users.forEach((user) => {
+  sourceUsers.forEach((user) => {
     temp_contacts.push({
       contactColor: user.contactColor,
       id: user.id,

--- a/js/login.js
+++ b/js/login.js
@@ -50,7 +50,15 @@ function checkIfUserWasPreviouslyRegistered() {
  * @return {Promise<void>} A promise that resolves when users are loaded and migrated if needed.
  */
 async function loadUsers() {
-    users = await firebaseGetItem(FIREBASE_USERS_ID);
+    const loadResult = await firebaseGetArraySafe(FIREBASE_USERS_ID, {
+        context: "users",
+        showErrorMessage: false,
+    });
+    users = loadResult.data;
+
+    if (loadResult.error) {
+        throw loadResult.error;
+    }
 
     if (!Array.isArray(users)) {
         users = [];
@@ -348,4 +356,3 @@ function checkIfFormIsValid() {
     return false;
   }
 }
-

--- a/js/signUp.js
+++ b/js/signUp.js
@@ -30,7 +30,14 @@ async function addNewUser() {
         return;
     }
     
-    users = await firebaseGetItem(FIREBASE_USERS_ID);
+    const loadResult = await firebaseGetArraySafe(FIREBASE_USERS_ID, {
+        context: 'users',
+        errorMessage: 'Could not load users. Please try again.',
+    });
+    if (loadResult.error) {
+        return;
+    }
+    users = loadResult.data;
     getInputValues();
     if (!checkPasswordsEqual()) {
         showUserMessage('Passwords do not match!');

--- a/js/summary.js
+++ b/js/summary.js
@@ -9,8 +9,11 @@ let mobileGreetingTimeoutId = null;
  */
 async function summaryInit() {
     includeHTML();
-    // await getContactsFromRemoteStorage();
-    await firebaseGetItem(FIREBASE_USERS_ID);
+    const usersLoadResult = await firebaseGetArraySafe(FIREBASE_USERS_ID, {
+        context: 'contacts',
+        errorMessage: 'Could not load contacts for summary.',
+    });
+    users = usersLoadResult.data;
     getContactsOutOfUsers();
     await loadTasksFromRemoteStorage();
     getLoggedUser();


### PR DESCRIPTION
## Goal
This PR hardens Firebase read flows so null payloads and request failures no longer break runtime behavior.

Closes #4

## Problem
Several call sites assumed `firebaseGetItem()` always returns a valid array.  
When Firebase returned `null` (empty node) or a request failed, follow-up operations like `forEach`, `find`, and `push` could throw runtime errors and break UI flows.

## What changed

### 1. Added safe Firebase read utilities
- Introduced `firebaseGetArraySafe(...)` in `js/storage.js`
  - wraps `firebaseGetItem(...)` with try/catch
  - normalizes payloads (`array`, `object`, `null`) into a safe array
  - returns `{ data, error }`
- Added `normalizeFirebaseArrayPayload(...)` helper
- Added `showGlobalUserMessage(...)` fallback user-feedback helper
  - uses `showUserMessage(...)` when available
  - otherwise renders a lightweight toast

### 2. Guarded affected read call sites
- `js/login.js`
  - `loadUsers()` now uses safe read wrapper and fails gracefully
- `js/signUp.js`
  - user load before signup now aborts safely on read failure with user feedback
- `js/contacts.js`
  - `getContactsFromRemoteStorage()` now returns safe load result
  - `getContactsOutOfUsers()` now handles non-array states safely
- `js/contact_popups.js`
  - create/edit/delete contact flows now guard load failures and early-return
  - avoid continuing write logic when initial read failed
- `js/addTask_tasks.js`
  - `loadTasksFromRemoteStorage()` now uses safe wrapper and returns load result
  - `createTask()` aborts when task read failed
- `js/board.js`
  - `saveEditedTask()` aborts when task read failed
- `js/summary.js`
  - summary init now reads users through safe wrapper before contact extraction

## Result
- No uncaught runtime errors from null/error Firebase reads in the affected flows.
- UI paths now fail safely and show user-facing feedback for failed load operations.
- Data operations no longer proceed on failed read preconditions.

## Validation
- `node --check` passed for all `js/*.js` files and `script.js`.
- Manual checks to run:
  1. Simulate empty Firebase node (`null`) and open login/contacts/addTask.
  2. Simulate temporary network failure and trigger read-dependent actions.
  3. Confirm:
     - no uncaught console runtime errors
     - user-facing error feedback is shown
     - write flows abort safely when reads fail.
