### PR TITLE
chore: remove debug logs and run JS syntax check on push and PR

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,6 +1,7 @@
 name: PR Tests
 
 on:
+  push:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
 
@@ -23,8 +24,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          files=$(find js -type f -name "*.js" -print)
+          files=$(find js -type f -name "*.js" -print | sort)
           for f in $files script.js; do
+            echo "Checking syntax: $f"
             node --check "$f"
           done
 

--- a/js/board.js
+++ b/js/board.js
@@ -326,7 +326,6 @@ function renderEditCardAssignedContacts(){
  * @param {number} taskId - The ID of the task to be saved.
  */
 async function saveEditedTask(taskId) {
-    console.log("saveEditedTask: Speichern gestartet für Task:", taskId);
     const loadResult = await loadTasksFromRemoteStorage();
     if (loadResult.error) {
         return;

--- a/js/filepicker.js
+++ b/js/filepicker.js
@@ -48,14 +48,12 @@ function setupDragAndDrop() {
     event.preventDefault();
     event.stopPropagation();
     dropArea.classList.add("dragging");
-    console.log("dragover event on addImageBottom");
   }, true);
   
   dropArea.addEventListener("dragleave", (event) => {
     event.preventDefault();
     event.stopPropagation();
     dropArea.classList.remove("dragging");
-    console.log("dragleave event on addImageBottom");
   }, true);
   
   dropArea.addEventListener("drop", (event) => {
@@ -63,7 +61,6 @@ function setupDragAndDrop() {
     event.stopPropagation();
     dropArea.classList.remove("dragging");
     const files = event.dataTransfer.files;
-    console.log("Dropped files:", files);
     if (files.length > 0) {
       handleFiles(files, getCurrentImageContainer());
     }
@@ -224,7 +221,6 @@ function getCurrentImageContainer() {
 function observeContainer() {
   const observer = new MutationObserver(() => {
     if (document.getElementById("subtasksImageContainer")) {
-      console.log("Container wurde geladen!");
       renderAddTaskImages();
       observer.disconnect();
     }


### PR DESCRIPTION
## Summary
This PR resolves #8 by removing leftover debug logs from production JS files and ensuring a minimal JS syntax check runs on both push and pull request events.

## Changes
- Removed debug `console.log` statements from:
  - `js/board.js`
  - `js/filepicker.js`
- Updated CI workflow:
  - `pr-tests.yml` now triggers on `push` and `pull_request`
  - Syntax check step now prints the current file before running `node --check` for clearer failure output

## Validation
- Verified no `console.log` / `console.debug` remains in app JS sources.
- Ran local syntax checks with `node --check` on all JS files successfully.

Closes #8.
