### PR TITLE
fix: initialize image drop area after dynamic add task render

### DIFF
--- a/js/addTask.js
+++ b/js/addTask.js
@@ -27,6 +27,9 @@ function renderAddTaskHTML() {
     setPriority('medium');
     renderContactsToDropdown();
     renderSubtasks();
+    if (typeof initializeFilepickerUI === "function") {
+        initializeFilepickerUI();
+    }
   }
 
 
@@ -396,7 +399,6 @@ function deactivateButton(id){
         btn.removeAttribute("onclick");
     }
 }
-
 
 
 

--- a/js/board.js
+++ b/js/board.js
@@ -287,7 +287,12 @@ function renderEditContainer(){
     container.innerHTML = createEditHeader();
     container.innerHTML += renderAddTaskMainContentHTML();
     container.innerHTML += createEditFooter(newTask);
-    addFilepickerListener();
+    if (typeof initializeFilepickerUI === "function") {
+        initializeFilepickerUI();
+    } else {
+        addFilepickerListener();
+        setupDragAndDrop();
+    }
 }
 
 

--- a/js/board_popups.js
+++ b/js/board_popups.js
@@ -98,7 +98,12 @@ function showAddTaskContainer(category='category-0') {
     newTask.category = category;
     if (!document.getElementById('addTaskHoverContainer')) {
         renderBoardAddTaskOverlay();
-        addFilepickerListener();
+        if (typeof initializeFilepickerUI === "function") {
+            initializeFilepickerUI();
+        } else {
+            addFilepickerListener();
+            setupDragAndDrop();
+        }
     }
     let container = document.getElementById('addTaskHoverContainer');
     container.classList.add('showBoard');
@@ -197,4 +202,3 @@ function createSuccessMessageContainer(){
 
     document.body.appendChild(div);
 }
-


### PR DESCRIPTION
## Summary
This PR fixes issue #18 by stabilizing image drop-area initialization for Add Task flows.

Closes #18.

## Problem
The console error `Drop-Bereich 'addImageBottom' nicht gefunden!` occurred because `filepicker.js` initialized before the Add Task DOM was fully rendered.  
As a result, drag-and-drop was not reliably available.

## What changed

### 1. Robust, idempotent filepicker initialization
- Introduced `initializeFilepickerUI()` as a single entry point.
- Added safe re-initialization logic to avoid duplicate event listeners.
- Added MutationObserver-based waiting for dynamically rendered drop area (`#addImageBottom`).
- Replaced hard failure path when drop area is temporarily missing.

### 2. Re-bind after dynamic Add Task rendering
- `renderAddTaskHTML()` now triggers filepicker UI initialization after rendering the Add Task markup.

### 3. Re-bind in board overlay/edit flows
- Added the same initialization call in:
  - task edit container rendering
  - board add-task overlay rendering
- Includes fallback behavior if the initializer is not available.

## Files changed
- `js/filepicker.js`
- `js/addTask.js`
- `js/board.js`
- `js/board_popups.js`

## Validation
- Ran JavaScript syntax checks (`node --check`) on all project JS files successfully.
- Verified initialization calls exist in all Add Task entry points (page, edit modal, board overlay).

## Expected result
- No more `Drop-Bereich 'addImageBottom' nicht gefunden!` on `addTask.html`.
- Drag-and-drop attachment area works reliably after page load and in dynamic overlays/modals.