### PR TITLE
fix(contacts): remove signup email-check dependency in contact creation

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -54,6 +54,32 @@ function normalizeAuthEmail(email) {
     return email.trim().toLowerCase();
 }
 
+function doesEmailExist(usersList, emailToCheck, options = {}) {
+    if (!Array.isArray(usersList)) {
+        return false;
+    }
+
+    const normalizedMail = normalizeAuthEmail(emailToCheck);
+    if (normalizedMail === "") {
+        return false;
+    }
+
+    const hasExcludeId = Object.prototype.hasOwnProperty.call(options, "excludeId");
+    const excludeId = hasExcludeId ? options.excludeId : null;
+
+    return usersList.some((user) => {
+        if (!user || typeof user !== "object") {
+            return false;
+        }
+
+        if (hasExcludeId && user.id === excludeId) {
+            return false;
+        }
+
+        return normalizeAuthEmail(user.mail) === normalizedMail;
+    });
+}
+
 async function derivePasswordHash(password, saltHex, iterations) {
     if (typeof password !== "string" || password.length === 0) {
         throw new Error("Password must be a non-empty string.");

--- a/js/contact_popups.js
+++ b/js/contact_popups.js
@@ -9,31 +9,34 @@ async function saveContact() {
     return;
   }
 
-  if (checkMailExist(document.getElementById("contactMail").value)) {
-  } else {
-    try {
-      createBtn.disabled = true;
-      const newId = getNextId(users);
-      users.push({
-        id: newId,
-        name: contactName.value,
-        mail: contactMail.value,
-        phone: contactPhone.value,
-        contactColor: generateRandomColor(),
-      });
+  const enteredMail = document.getElementById("contactMail").value;
+  if (doesEmailExist(users, enteredMail)) {
+    showGlobalUserMessage("A contact with this email already exists.");
+    return;
+  }
 
-      await firebaseUpdateItem(users, FIREBASE_USERS_ID);
-      getContactsOutOfUsers();
-      users = [];
-      resetContactForm();
-      closeOverlay("addContact");
-      displaySuccessMessage("Contact successfully created");
-      loadContacts();
-    } catch (error) {
-      console.error("Error saving contact:", error);
-      showGlobalUserMessage("Could not save contact. Please try again.");
-      createBtn.disabled = false;
-    }
+  try {
+    createBtn.disabled = true;
+    const newId = getNextId(users);
+    users.push({
+      id: newId,
+      name: contactName.value,
+      mail: normalizeAuthEmail(enteredMail),
+      phone: contactPhone.value,
+      contactColor: generateRandomColor(),
+    });
+
+    await firebaseUpdateItem(users, FIREBASE_USERS_ID);
+    getContactsOutOfUsers();
+    users = [];
+    resetContactForm();
+    closeOverlay("addContact");
+    displaySuccessMessage("Contact successfully created");
+    loadContacts();
+  } catch (error) {
+    console.error("Error saving contact:", error);
+    showGlobalUserMessage("Could not save contact. Please try again.");
+    createBtn.disabled = false;
   }
 }
 

--- a/js/signUp.js
+++ b/js/signUp.js
@@ -42,7 +42,7 @@ async function addNewUser() {
     getInputValues();
     if (!checkPasswordsEqual()) {
         showUserMessage('Passwords do not match!');
-    } else if (checkMailExist(newMail)) {
+    } else if (doesEmailExist(users, newMail)) {
         showUserMessage('The mail already exists!');
     } else {
         try {
@@ -60,16 +60,6 @@ async function addNewUser() {
             showUserMessage('Sign up failed. Please try again.');
         }
     }
-}
-
-function checkMailExist(mailToCheck) {
-    const normalizedMail = normalizeAuthEmail(mailToCheck);
-    for (let i = 0; i < users.length; i++) {
-        if (normalizeAuthEmail(users[i].mail) === normalizedMail) {
-            return true;
-        }
-    }
-    return false;
 }
 
 function testMailinputWithRegex(){


### PR DESCRIPTION
## Summary
This PR fixes a contacts-page runtime dependency bug where `saveContact()` called `checkMailExist(...)`, even though that function was only defined in `signUp.js` and not loaded on `contacts.html`.

## What changed
- Added a shared helper in `js/auth.js`:
  - `doesEmailExist(usersList, emailToCheck, options = {})`
- Updated signup flow in `js/signUp.js` to use `doesEmailExist(...)` instead of a local `checkMailExist(...)`.
- Updated contact creation in `js/contact_popups.js`:
  - uses `doesEmailExist(...)` for duplicate-email validation
  - shows a clear user message when duplicate email is detected
  - stores contact email normalized via `normalizeAuthEmail(...)`

## Why
This removes cross-page coupling to signup-only code and prevents `ReferenceError: checkMailExist is not defined` in the contacts flow.

## Validation
- No remaining references to `checkMailExist(...)`.
- JavaScript syntax check passed (`node --check` across project files).
- Contact creation on `contacts.html` now validates duplicate emails without runtime errors.

## Issue
Closes #22
