### PR TITLE
fix(contacts): remove duplicate onclick attributes and add guardrail

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -30,6 +30,134 @@ jobs:
             node --check "$f"
           done
 
+      - name: Guardrail check for duplicate inline HTML attributes in templates
+        shell: bash
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const fs = require("fs");
+          const path = require("path");
+
+          const files = [];
+          const roots = ["js", "assets/templates"];
+
+          function collectJsFiles(dir) {
+            if (!fs.existsSync(dir)) return;
+            const entries = fs.readdirSync(dir, { withFileTypes: true });
+            for (const entry of entries) {
+              const fullPath = path.join(dir, entry.name);
+              if (entry.isDirectory()) {
+                collectJsFiles(fullPath);
+              } else if (entry.isFile() && fullPath.endsWith(".js")) {
+                files.push(fullPath);
+              }
+            }
+          }
+
+          for (const root of roots) {
+            collectJsFiles(root);
+          }
+
+          files.push("script.js");
+
+          function parseAttributeNames(attributeText) {
+            const names = [];
+            let i = 0;
+
+            while (i < attributeText.length) {
+              while (i < attributeText.length && /\s/.test(attributeText[i])) i++;
+              if (i >= attributeText.length) break;
+
+              if (attributeText[i] === "/") {
+                i++;
+                continue;
+              }
+
+              const start = i;
+              while (
+                i < attributeText.length &&
+                !/[\s=/>]/.test(attributeText[i])
+              ) {
+                i++;
+              }
+
+              if (i === start) {
+                i++;
+                continue;
+              }
+
+              names.push(attributeText.slice(start, i).toLowerCase());
+
+              while (i < attributeText.length && /\s/.test(attributeText[i])) i++;
+
+              if (i < attributeText.length && attributeText[i] === "=") {
+                i++;
+                while (i < attributeText.length && /\s/.test(attributeText[i])) i++;
+
+                if (
+                  i < attributeText.length &&
+                  (attributeText[i] === '"' || attributeText[i] === "'")
+                ) {
+                  const quote = attributeText[i];
+                  i++;
+                  while (i < attributeText.length && attributeText[i] !== quote) i++;
+                  if (i < attributeText.length && attributeText[i] === quote) i++;
+                } else {
+                  while (i < attributeText.length && !/[\s>]/.test(attributeText[i])) i++;
+                }
+              }
+            }
+
+            return names;
+          }
+
+          const violations = [];
+          const tagRegex = /<(?!\/|!)([A-Za-z][\w:-]*)([^<>\n]*)>/g;
+
+          for (const file of files) {
+            if (!fs.existsSync(file)) continue;
+            const source = fs.readFileSync(file, "utf8");
+            const lines = source.split(/\r?\n/);
+
+            lines.forEach((line, lineIndex) => {
+              let match;
+              while ((match = tagRegex.exec(line)) !== null) {
+                const attributeText = match[2] || "";
+                const names = parseAttributeNames(attributeText);
+                const counts = new Map();
+
+                for (const name of names) {
+                  counts.set(name, (counts.get(name) || 0) + 1);
+                }
+
+                const duplicates = [...counts.entries()]
+                  .filter(([, count]) => count > 1)
+                  .map(([name]) => name);
+
+                if (duplicates.length > 0) {
+                  const compactTag = match[0].replace(/\s+/g, " ").trim();
+                  violations.push(
+                    `${file}:${lineIndex + 1} duplicate attribute(s): ${duplicates.join(
+                      ", "
+                    )} | ${compactTag}`
+                  );
+                }
+              }
+              tagRegex.lastIndex = 0;
+            });
+          }
+
+          if (violations.length > 0) {
+            console.error("Duplicate inline HTML attributes found:");
+            for (const violation of violations) {
+              console.error(`- ${violation}`);
+            }
+            process.exit(1);
+          }
+
+          console.log("Duplicate attribute guardrail passed.");
+          NODE
+
       - name: Guardrail check for implicit globals in core scripts
         shell: bash
         run: |

--- a/js/contacts_render.js
+++ b/js/contacts_render.js
@@ -19,7 +19,7 @@ function generateContactsContainerHTML() {
   </div>
   <div class="contacts-container-outer">
     <div class="contacts-container" id="contacts-container"> 
-            <div onclick="addContactCard()" id="button-add-contact-card" class="button-add-contact"  onclick="doNotClose(event)">
+            <div id="button-add-contact-card" class="button-add-contact" onclick="addContactCard(); doNotClose(event)">
                 <div class="add-new-contact">Add new contact</div>
                 <img src="./assets/img/icon-person_add.png" alt="icon-person_add.png">
             </div>


### PR DESCRIPTION
## Summary
This PR fixes duplicate `onclick` attributes in contact template markup and adds a CI guardrail to prevent similar regressions.

## What was wrong
In contact template HTML, one element had duplicate `onclick` attributes.
In HTML parsing, duplicate attributes are ambiguous and one can override the other, which causes non-deterministic behavior.

## Changes
- Updated contact add-card button template to use exactly one click handler:
  - `onclick="addContactCard(); doNotClose(event)"`
- Added a CI guardrail step in `PR Tests`:
  - scans JS template markup for duplicate inline HTML attributes (same attribute name repeated in one tag)
  - fails the workflow with clear file/line output when duplicates are found

## Why this fixes it
Each interactive element now has one deterministic click handler, and the new CI guardrail blocks reintroduction of duplicate attributes in future PRs.

## Validation
- Local JS syntax checks passed.
- Local duplicate-attribute guardrail run passed.

## Issue
Closes #23
