### PR TITLE
refactor(contacts): remove duplicate id helper and DOM globals

### DIFF
--- a/js/contacts.js
+++ b/js/contacts.js
@@ -93,20 +93,6 @@ function getNextId(contactsArray) {
 
 
 /**
- * Finds the maximum id in the contactsArray and returns the next id.
- */
-function getNextId(contactsArray) {
-  let maxId = 0;
-  contactsArray.forEach((contact) => {
-    if (contact.id > maxId) {
-      maxId = contact.id;
-    }
-  });
-  return maxId + 1;
-}
-
-
-/**
  * Initializes the contacts by including the HTML and loading the contacts.
  *
  * @return {void} This function does not return anything.


### PR DESCRIPTION
## Summary
This PR refactors contact-related code to remove duplicate helper logic and replace fragile implicit DOM-global usage with explicit element access.

## Context
Two issues were present:
1. `getNextId()` was declared twice in `js/contacts.js`.
2. Contact popup flows relied on browser DOM-id globals (e.g. `createBtn`, `contactName`, `contactMail`, `contactPhone`, `addContactContainer`) instead of explicit lookups, which is brittle under stricter execution modes.

## Changes

### 1) Deduplicated contact ID helper
- Removed duplicate `getNextId()` declaration in `js/contacts.js`.
- Kept one single source of truth for ID helper behavior.

### 2) Removed implicit DOM-global dependencies in contact popup flow
In `js/contact_popups.js`, added explicit form helper functions:
- `getContactFormElements()`
- `hasCompleteContactForm(formElements)`
- `setContactFormValues(values)`

Updated flows to use explicit element references:
- `saveContact()`
- `resetContactForm()`
- `editContact()`
- `saveEditedContact()`
- `closeOverlay()`

Also added defensive checks to show a user message if form elements are unexpectedly unavailable.

## Why this helps
- Avoids ambiguous function ownership and maintenance drift.
- Makes contact popup logic deterministic and robust across browsers/modes.
- Reduces hidden coupling to DOM-id global behavior.

## Validation
- JS syntax checks passed.
- Create/edit/delete contact flows remain functionally unchanged.

## Issue
Closes #26
