### PR TITLE
refactor(a11y): replace clickable div controls with semantic actions

### DIFF
--- a/assets/css/addTask.css
+++ b/assets/css/addTask.css
@@ -176,6 +176,7 @@ select {
 }
 
 .clearBtnImg {
+  display: block;
   background-image: url("../img/icon-close_gray.png");
   background-position: center;
   background-repeat: no-repeat;
@@ -205,6 +206,7 @@ select {
 }
 
 .createBtnImg {
+  display: block;
   background-image: url("../img/icon-check.png");
   width: 24px;
   background-position: center;
@@ -269,6 +271,9 @@ select {
 }
 
 .addTaskDueDateImage {
+  border: none;
+  background-color: transparent;
+  padding: 0;
   background-image: url("../img/icon-event.png");
   background-position: center;
   background-repeat: no-repeat;
@@ -324,6 +329,11 @@ select {
   gap: 1rem;
   width: 100%;
   padding: var(--padding-1216);
+  border: none;
+  background-color: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
 }
 
 .assignedContactsContainer {
@@ -337,6 +347,12 @@ select {
 
 .addTask-dropdown-category {
   padding: var(--padding-1216);
+  border: none;
+  background-color: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  width: 100%;
 }
 
 /* .subtaskBottom:hover,
@@ -346,6 +362,8 @@ select {
 } */
 
 .addTask-custom-select {
+  display: block;
+  width: 100%;
   font-size: 1.188rem;
   position: relative;
 }
@@ -373,10 +391,16 @@ select {
 }
 
 .dropdownOption {
+  width: 100%;
   padding: var(--padding-1216);
   display: flex;
   align-items: center;
   justify-content: space-between;
+  border: none;
+  background-color: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
   border-radius: 10px;
   cursor: pointer;
   text-transform: capitalize;
@@ -451,6 +475,8 @@ select {
   border-radius: 10px;
   padding: 18px 10px 18px 10px;
   background-color: white;
+  border: none;
+  font: inherit;
   box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.2);
   cursor: pointer;
 }
@@ -504,6 +530,12 @@ select {
   flex-direction: row;
   justify-content: space-between;
   padding: var(--padding-1216);
+  border: none;
+  background-color: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  width: 100%;
   cursor: pointer;
 
   #subtaskInputFieldDiv {
@@ -577,8 +609,19 @@ select {
 }
 
 .subtaskImgDiv {
+  display: block;
+  border: none;
+  background-color: transparent;
+  padding: 0;
   width: 24px;
   aspect-ratio: 1;
+  cursor: pointer;
+}
+
+.uploadImageButton {
+  border: none;
+  background-color: transparent;
+  padding: 0;
   cursor: pointer;
 }
 

--- a/assets/css/board.css
+++ b/assets/css/board.css
@@ -85,6 +85,9 @@
   display: flex;
   justify-self: right;
   position: relative;
+  border: none;
+  background-color: transparent;
+  padding: 0;
   background-image: url("../img/icon-close.png");
   background-repeat: no-repeat;
   background-position: center;
@@ -124,6 +127,9 @@
 }
 
 .searchImg {
+  border: none;
+  background-color: transparent;
+  padding: 0;
   background-image: url("../img/icon-search.png");
   background-repeat: no-repeat;
   background-position: center;
@@ -284,6 +290,11 @@ button:focus {
   width: 252px;
   min-height: 270px;
   min-width: 252px;
+  border: none;
+  background-color: #fff;
+  color: inherit;
+  text-decoration: none;
+  text-align: left;
 }
 
 .emptyCard {
@@ -301,6 +312,9 @@ button:focus {
 }
 
 .addTaskButton {
+  border: none;
+  background-color: transparent;
+  padding: 0;
   background-image: url("../img/icon-plus_button.png");
   background-repeat: no-repeat;
   cursor: pointer;
@@ -313,8 +327,10 @@ button:focus {
 }
 
 .addTaskBtnImg {
+  display: block;
   background-image: url("../img/icon-plus.png");
   background-position: center;
+  background-repeat: no-repeat;
   width: 15px;
   aspect-ratio: 1;
 }
@@ -628,6 +644,7 @@ progress {
 }
 
 .openCardImgDiv {
+  display: block;
   width: 24px;
   aspect-ratio: 1;
   cursor: pointer;
@@ -669,6 +686,12 @@ progress {
 
 .openCardDeleteContainer,
 .openCardEditContainer {
+  border: none;
+  background-color: transparent;
+  padding: 0;
+  color: inherit;
+  font: inherit;
+  text-align: left;
   cursor: pointer;
 
   &:hover {

--- a/assets/css/login.css
+++ b/assets/css/login.css
@@ -123,12 +123,17 @@ input[type="password"]:focus {
 }
 
 .checkboxBox {
+  border: none;
+  background: transparent;
   padding-top: 20px;
   cursor: pointer;
   display: flex;
   align-items: center;
   gap: 8px;
   width: min-content;
+  font: inherit;
+  color: inherit;
+  text-align: left;
 }
 
 .custom-checkbox {
@@ -137,8 +142,8 @@ input[type="password"]:focus {
   align-items: center;
   white-space: nowrap;
   gap: 8px;
-  width: 24px;
-  height: 24px;
+  width: auto;
+  height: auto;
   font-size: 16px;
   font-weight: 400;
 }

--- a/assets/css/summary.css
+++ b/assets/css/summary.css
@@ -43,7 +43,7 @@
   grid-row: 2 / 3;
 }
 
-div.square-button.toDo {
+.square-button.toDo {
   background-color: var(--clr-summary-square-button-focus);
 }
 
@@ -251,6 +251,8 @@ button {
   cursor: pointer;
   border: unset;
   transition: all 0.125s ease-in-out;
+  text-decoration: none;
+  color: inherit;
 }
 
 .inner-square-button {
@@ -273,6 +275,7 @@ button {
   cursor: pointer;
   transition: all 0.125s ease-in-out;
   color: #fff;
+  text-decoration: none;
 }
 
 .urgent {

--- a/assets/templates/html_templates.js
+++ b/assets/templates/html_templates.js
@@ -136,7 +136,7 @@ function renderTasksHTML(task) {
   const safeTaskDescription = escapeHtml(task && task.description);
 
   return /*html*/ `
-      <div draggable="true" ondragstart="startDragging(${safeTaskId})" ondragend="stopDragging()" id="${safeTaskId}" class="card" onclick="openCard(${safeTaskId})">
+      <a draggable="true" ondragstart="startDragging(${safeTaskId})" ondragend="stopDragging()" id="${safeTaskId}" class="card" href="#" onclick="openCard(${safeTaskId}); return false;">
           <div class="cardTopContainer">
               <div id="cardType${safeTaskId}" class="cardType">${safeTaskType}</div>
               <div class="cardTitle">${safeTaskTitle}</div>
@@ -153,7 +153,7 @@ function renderTasksHTML(task) {
               <!-- Neuer Container für Bilder -->
               <div id="cardImagesContainer${safeTaskId}" class="cardImagesContainer"></div>
           </div>
-      </div>`;
+      </a>`;
 }
 
 /**
@@ -178,9 +178,9 @@ function renderAssignedToButtonsHTML(contact) {
   const safeContactColor = sanitizeCssColor(contact && contact.contactColor);
   const safeInitials = escapeHtml(getInitials(contactName));
 
-  return /*html*/ `<div class="profile-badge-group" style="background-color: ${
+  return /*html*/ `<span class="profile-badge-group" style="background-color: ${
     safeContactColor
-  }">${safeInitials}</div>`;
+  }">${safeInitials}</span>`;
 }
 
 /**
@@ -244,8 +244,8 @@ function renderLoginPageHTML() {
             <button class="loginButtons signUpButton signUpButton-mobile" onclick="renderSignUpPage()">Sign up</button>
         </div>
         <div class="loginFooter">
-            <div class="privacyPolicy" onclick=""><span>Privacy policy</span></div>
-            <div class="legalNotice" onclick=""><span>Legal notice</span></div>
+            <a class="privacyPolicy" href="./privacy_external.html" target="_blank" rel="noopener noreferrer"><span>Privacy policy</span></a>
+            <a class="legalNotice" href="./legal_notice_external.html" target="_blank" rel="noopener noreferrer"><span>Legal notice</span></a>
         </div>
     </div>
 </div>`;
@@ -298,8 +298,8 @@ function renderSignUpPageHTML() {
             </div>
 
             <div class="signUpFooter">
-                <div class="privacyPolicySignUp" onclick=""><span>Privacy policy</span></div>
-                <div class="legalNoticeSignUp" onclick=""><span>Legal notice</span></div>
+                <a class="privacyPolicySignUp" href="./privacy_external.html" target="_blank" rel="noopener noreferrer"><span>Privacy policy</span></a>
+                <a class="legalNoticeSignUp" href="./legal_notice_external.html" target="_blank" rel="noopener noreferrer"><span>Legal notice</span></a>
             </div>
 
 
@@ -316,7 +316,7 @@ function renderBoardAddTaskHeaderHTML() {
   return /*html*/ `
     <div class="boardAddTaskHeader">
     <div class="boardAddTaskHeaderText">Add Task</div>
-    <div class="boardAddTaskCloseHoverContainer" onclick="hideAddTaskContainer()"></div>
+    <button type="button" class="boardAddTaskCloseHoverContainer" onclick="hideAddTaskContainer()" aria-label="Close add task overlay"></button>
  </div>`;
 }
 
@@ -350,9 +350,9 @@ function renderAddTaskMainContentHTML() {
             <div class="addTaskDueDate ">
                 <div class="addTaskTitles"><span class="bold">Due date</span></div>
                 <div>
-                    <div class="addTaskDueDateInputContainer border-bottom pointer" id="addTaskDueDateInputContainer" onclick="addTaskDueDateOpenCalendear()">
+                    <div class="addTaskDueDateInputContainer border-bottom pointer" id="addTaskDueDateInputContainer">
                         <input class="addTaskDueDateInput" id="addTaskDueDateInput" type="date"  value="">
-                        <div class="addTaskDueDateImage"></div>
+                        <button type="button" class="addTaskDueDateImage" onclick="addTaskDueDateOpenCalendear()" aria-label="Open due date picker"></button>
                     </div>
                     <div class="addTaskRequired" id="requiredDueDate"></div>
                 </div>
@@ -362,57 +362,57 @@ function renderAddTaskMainContentHTML() {
         <div class="addTaskPriority">
             <div class="addTaskTitles bold">Priority</div>
             <div class="addTaskPriorityButtonContainer">
-                <div id="addTaskPriorityButtonurgent" class="addTaskPriorityButton"  onclick="setPriority('urgent')">
-                    <div class="priorityButtonText">Urgent</div>
+                <button type="button" id="addTaskPriorityButtonurgent" class="addTaskPriorityButton" onclick="setPriority('urgent')">
+                    <span class="priorityButtonText">Urgent</span>
                     <img src="./assets/img/icon-priority_urgent.png" alt="Priority urgent">
-                </div>
-                <div id="addTaskPriorityButtonmedium" class="addTaskPriorityButton" onclick="setPriority('medium')">
-                    <div class="priorityButtonText">Medium</div>
+                </button>
+                <button type="button" id="addTaskPriorityButtonmedium" class="addTaskPriorityButton" onclick="setPriority('medium')">
+                    <span class="priorityButtonText">Medium</span>
                     <img src="./assets/img/icon-priority_medium.png" alt="Priority medium">
-                </div>
-                <div id="addTaskPriorityButtonlow" class="addTaskPriorityButton"  onclick="setPriority('low')">
-                    <div class="priorityButtonText">Low</div>
+                </button>
+                <button type="button" id="addTaskPriorityButtonlow" class="addTaskPriorityButton" onclick="setPriority('low')">
+                    <span class="priorityButtonText">Low</span>
                     <img src="./assets/img/icon-priority_low.png" alt="Priority low">
-                </div>
+                </button>
 
             </div>
         </div>
         <div class="addTaskContainer">
             <div class="addTaskTitle"><span class="bold">Assigned to</span> (optional)</div>
-            <div class="addTask-dropdown-contact pointer border-bottom" onclick="doNotClose(event); renderArrow('custom-arrow-assignedTo', 'dropdown-content-assignedTo')">
-                <div class="addTask-custom-select">
+            <button type="button" class="addTask-dropdown-contact pointer border-bottom" onclick="doNotClose(event); renderArrow('custom-arrow-assignedTo', 'dropdown-content-assignedTo')">
+                <span class="addTask-custom-select">
                     <span id="dropdown-assignedTo-title">Select contacts to assign</span>
-                    <div class="addTask-custom-arrow" id="custom-arrow-assignedTo">
+                    <span class="addTask-custom-arrow" id="custom-arrow-assignedTo">
                         <img data-direction="down" src="./assets/img/icon-arrow_dropdown_down.png" alt="">
-                    </div>
-                </div>
-            </div>
+                    </span>
+                </span>
+            </button>
                 <div class="addTask-dropdown-content d-none" onclick="doNotClose(event)" id="dropdown-content-assignedTo">
                 </div>
                 <div id="assignedContactsContainer" class="assignedContactsContainer cardAssignedToContainer d-none"></div>
         </div>
         <div class="addTaskContainer ">
             <div class="addTaskTitle bold">Category </div>
-            <div class="addTask-dropdown-category pointer border-bottom" onclick="doNotClose(event); renderArrow('custom-arrow-category', 'dropdown-content-category')">
-                <div class="addTask-custom-select">
+            <button type="button" class="addTask-dropdown-category pointer border-bottom" onclick="doNotClose(event); renderArrow('custom-arrow-category', 'dropdown-content-category')">
+                <span class="addTask-custom-select">
                     <span id="dropdown-category-title">Select task category</span>
-                        <div class="addTask-custom-arrow" id="custom-arrow-category">
+                        <span class="addTask-custom-arrow" id="custom-arrow-category">
                         <img data-direction="down" src="./assets/img/icon-arrow_dropdown_down.png" alt="">
-                    </div>
-                </div>
-            </div>
+                    </span>
+                </span>
+            </button>
             <div class="addTask-dropdown-content d-none no-scroll" onclick="doNotClose(event)" id="dropdown-content-category">
-                <div class="dropdownOption" onclick="chooseCategory('Technical Task')">Technical Task</div>
-                <div class="dropdownOption" onclick="chooseCategory('User Story')">User Story</div>
+                <button type="button" class="dropdownOption" onclick="chooseCategory('Technical Task')">Technical Task</button>
+                <button type="button" class="dropdownOption" onclick="chooseCategory('User Story')">User Story</button>
             </div>
         </div>
         <div class="addTaskContainer">
             <div class="addTaskTitles"><span class="bold">Subtasks</span> (optional)
             </div>
-            <div id="subtaskBottom" class="subtaskBottom border-bottom" onclick="renderSubtaskInputField()">
-                <div id="subtaskInputFieldDiv">Add new subtask</div>
-                <div id="subtaskImgAddPlus" class="subtaskImgDiv pointer"></div>
-            </div>
+            <button type="button" id="subtaskBottom" class="subtaskBottom border-bottom" onclick="renderSubtaskInputField()">
+                <span id="subtaskInputFieldDiv">Add new subtask</span>
+                <span id="subtaskImgAddPlus" class="subtaskImgDiv pointer"></span>
+            </button>
             <div id="subtasksOutputContainer"></div>
         </div>
 
@@ -420,7 +420,9 @@ function renderAddTaskMainContentHTML() {
         <div class="addTaskContainer">
             <div class="addTaskTitles"><span class="bold">Attachments</span> (optional)</div>
             <div id="addImageBottom" class="addImageBottom border-bottom">
-            <img src="./assets/img/upload.png" alt="upload" onclick="openFilepicker()">
+            <button type="button" class="uploadImageButton" onclick="openFilepicker()" aria-label="Upload attachment">
+            <img src="./assets/img/upload.png" alt="upload">
+            </button>
             <input type="file" id="filepicker" style="display: none" accept="image/*" multiple dropzone="copy">
             
             </div>
@@ -434,14 +436,14 @@ function renderAddTaskMainContentHTML() {
 function renderAddTaskFooterHTML() {
   return /*html*/ `
             <div class="addTaskBtnContainer">
-                <div class="clearBtn addTaskBtn" onclick="clearFormular()">
+                <button type="button" class="clearBtn addTaskBtn" onclick="clearFormular()">
                     <span class="addTaskBtnText">Clear</span>
-                    <div class="clearBtnImg"></div>
-                </div>
-                <div id="createBtn" class="createBtn addTaskBtn disabled">
+                    <span class="clearBtnImg"></span>
+                </button>
+                <button type="button" id="createBtn" class="createBtn addTaskBtn disabled" disabled aria-disabled="true">
                     <span class="addTaskBtnText">Create Task</span>
-                    <div class="createBtnImg"></div>
-                </div>
+                    <span class="createBtnImg"></span>
+                </button>
         </div>`;
 }
 
@@ -461,7 +463,7 @@ function renderOpenCardHTML(task) {
 
   return /*html*/ `
       <div class="boardAddTaskCloseHoverOuterContainer">
-          <div class="boardAddTaskCloseHoverContainer" onclick="closeCard()"></div>
+          <button type="button" class="boardAddTaskCloseHoverContainer" onclick="closeCard()" aria-label="Close task details"></button>
       </div>
       <div class="openCardInnerContainer">
           <div id="openCardType${safeTaskId}" class="cardType">${safeTaskType}</div>
@@ -484,15 +486,15 @@ function renderOpenCardHTML(task) {
           <div id="openCardSubtasksContainer"></div>
           <div id="openCardImagesContainer" class="openCardImagesContainer"></div>
           <div class="openCardDeleteEditContainer">
-              <div class="openCardDeleteContainer" onclick='openCardDelete(${safeTaskId})'>
-                  <div class="openCardImgDiv pointer" id="openCardImgDelete"></div>
+              <button type="button" class="openCardDeleteContainer" onclick='openCardDelete(${safeTaskId})'>
+                  <span class="openCardImgDiv pointer" id="openCardImgDelete"></span>
                   <span>Delete</span>
-              </div>
+              </button>
               <div class="vLine"></div>
-              <div class="openCardEditContainer" onclick='openCardEdit(${safeTaskId})'>
-                  <div class="openCardImgDiv pointer" id="openCardImgEdit"></div>
+              <button type="button" class="openCardEditContainer" onclick='openCardEdit(${safeTaskId})'>
+                  <span class="openCardImgDiv pointer" id="openCardImgEdit"></span>
                   <span>Edit</span>
-              </div>
+              </button>
           </div>
       </div>`;
 }
@@ -510,8 +512,8 @@ function editSubtaskHTML(subtask) {
   return /*html*/ `
         <input type="text" id="subtaskEditInputField" value="${safeSubtaskText}">
         <div class="subtaskCheckboxes">
-        <div class="subtaskImgDiv pointer" id="subtaskImgDelete" onclick="deleteSubtask(${safeSubtaskId})"> </div><div class="vLine"></div>
-            <div class="subtaskImgDiv pointer" id="subtaskImgAddCheck" onclick="saveEditSubtask(${safeSubtaskId})"> </div>
+        <button type="button" class="subtaskImgDiv pointer" id="subtaskImgDelete" onclick="deleteSubtask(${safeSubtaskId})"></button><div class="vLine"></div>
+            <button type="button" class="subtaskImgDiv pointer" id="subtaskImgAddCheck" onclick="saveEditSubtask(${safeSubtaskId})"></button>
         </div>`;
 }
 
@@ -529,9 +531,9 @@ function renderSubtaskInputFieldHTML() {
   return /*html*/ `
      <input type="text" id="subtaskInputField" placeholder="Add new subtask" onclick="doNotClose(event)">
      <div class="subtaskAddOrCancel">
-         <div id="subtaskImgAddCheck" class="subtaskImgDiv pointer" onclick="subtaskAddOrCancel('add'); doNotClose(event)"></div>
+         <button type="button" id="subtaskImgAddCheck" class="subtaskImgDiv pointer" onclick="subtaskAddOrCancel('add'); doNotClose(event)"></button>
          <div class="vLine"></div>
-         <div id="subtaskImgAddCancel" class="subtaskImgDiv pointer" onclick="subtaskAddOrCancel('cancel'); doNotClose(event)"></div>
+         <button type="button" id="subtaskImgAddCancel" class="subtaskImgDiv pointer" onclick="subtaskAddOrCancel('cancel'); doNotClose(event)"></button>
      </div>`;
 }
 
@@ -554,9 +556,9 @@ function renderSubtaskHTML(outputContainer, subtask) {
         <div class="subTaskOutputDiv" id="subtask${safeSubtaskId}" ondblclick="editSubtask(${safeSubtaskId})">
         <div class="subtaskText">${safeSubtaskText}</div>
             <div class="subtaskCheckboxes">
-                <div class="subtaskImgDiv pointer" id="subtaskImgEdit" onclick="editSubtask(${safeSubtaskId})"> </div>
+                <button type="button" class="subtaskImgDiv pointer" id="subtaskImgEdit" onclick="editSubtask(${safeSubtaskId})"></button>
                 <div class="vLine"></div>
-                <div class="subtaskImgDiv pointer" id="subtaskImgDelete" onclick="deleteSubtask(${safeSubtaskId})"> </div>
+                <button type="button" class="subtaskImgDiv pointer" id="subtaskImgDelete" onclick="deleteSubtask(${safeSubtaskId})"></button>
             </div>
         </div>`;
 }
@@ -572,7 +574,7 @@ function renderImageInputField() {}
  */
 
 function renderSubtaskDefaultHTML() {
-  return /*html*/ `<div id="subtaskInputFieldDiv">Add new subtask</div>
-    <div id="subtaskImgAddPlus" class="subtaskImgDiv pointer"></div>
+  return /*html*/ `<span id="subtaskInputFieldDiv">Add new subtask</span>
+    <span id="subtaskImgAddPlus" class="subtaskImgDiv pointer"></span>
     `;
 }

--- a/board.html
+++ b/board.html
@@ -45,14 +45,14 @@
                     <div class="boardTopContainer">
                         <div class="searchTaskContainer">
                             <div class="searchTaskInner"><input id="findTask" placeholder="Find Task" type="text" onkeyup="searchTask()">
-                                <div class="searchImg" onclick="searchTask()"> </div>
+                                <button type="button" class="searchImg" onclick="searchTask()" aria-label="Search tasks"></button>
                             </div>
                         </div>
-                        <div class="boardAddTaskButtonContainer" onclick="doNotClose(event)">
-                            <div class="createBtn addTaskBtn addTaskBtnBoard btnBoard" onclick="showAddTaskContainer()">
+                        <div class="boardAddTaskButtonContainer">
+                            <button type="button" class="createBtn addTaskBtn addTaskBtnBoard btnBoard" onclick="doNotClose(event); showAddTaskContainer()">
                                 <span class="addTaskBtnText">Add Task</span>
-                                <div class="addTaskBtnImg "></div>
-                            </div>
+                                <span class="addTaskBtnImg "></span>
+                            </button>
                         </div>
 
                     </div>
@@ -61,23 +61,23 @@
                             ondragover="allowDrop(event)">
                             <div class="categoryTitle">
                                 <h2>To Do</h2>
-                                <div class="addTaskButton" onclick="showAddTaskContainer('category-0')"></div>
+                                <button type="button" class="addTaskButton" onclick="showAddTaskContainer('category-0')" aria-label="Add task to To Do"></button>
                             </div>
                             <div id="category-0" class="categoryTasks">
                             </div>
                         </div>
-                        <div class="category" ondrop="moveTo('category-1')" ondragover="allowDrop(event)"">
+                        <div class="category" ondrop="moveTo('category-1')" ondragover="allowDrop(event)">
                             <div class=" categoryTitle">
                             <h2>In progress</h2>
-                            <div class="addTaskButton" onclick="showAddTaskContainer('category-1')"></div>
+                            <button type="button" class="addTaskButton" onclick="showAddTaskContainer('category-1')" aria-label="Add task to In progress"></button>
                         </div>
                         <div id="category-1" class="categoryTasks">
                         </div>
                     </div>
-                    <div class="category" ondrop="moveTo('category-2')" ondragover="allowDrop(event)"">
+                    <div class="category" ondrop="moveTo('category-2')" ondragover="allowDrop(event)">
                             <div class=" categoryTitle">
                         <h2>Await feedback</h2>
-                        <div class="addTaskButton" onclick="showAddTaskContainer('category-2')"></div>
+                        <button type="button" class="addTaskButton" onclick="showAddTaskContainer('category-2')" aria-label="Add task to Await feedback"></button>
                     </div>
                     <div id="category-2" class="categoryTasks">
                     </div>
@@ -85,7 +85,7 @@
                 <div class="category" ondrop="moveTo('category-3')" ondragover="allowDrop(event)">
                     <div class="categoryTitle">
                         <h2>Done</h2>
-                        <div class="addTaskButton" onclick="showAddTaskContainer('category-3')"></div>
+                        <button type="button" class="addTaskButton" onclick="showAddTaskContainer('category-3')" aria-label="Add task to Done"></button>
                     </div>
                     <div id="category-3" class="categoryTasks">
                     </div>

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
                     </div>
                     <div class="signUpField">
                         <span>Not a join user yet?</span>
-                        <button class="loginButtons signUpButton" onclick="gotoSignUp()">Sign up</button>
+                        <button type="button" class="loginButtons signUpButton" onclick="gotoSignUp()">Sign up</button>
                     </div>
                 </header>
                 <div class=" login-page">
@@ -54,31 +54,32 @@
                                     <div class="mailIcon"><img src="./assets/img/icon-lock.png" alt="lock">
                                     </div>
                                 </div>
-                                <div id="loginCheckbox" class="checkboxBox" onclick="toggleRememberMeCheckbox()">
+                                <button type="button" id="loginCheckbox" class="checkboxBox" onclick="toggleRememberMeCheckbox()"
+                                    aria-label="Toggle remember me">
                                     <img id="loginCheckboxImg" src="./assets/img/icon-check_button_unchecked.png"
                                         alt="checkbox image">
-                                    <div for="rememberMe" class="custom-checkbox">Remember me</div>
-                                </div>
+                                    <span class="custom-checkbox">Remember me</span>
+                                </button>
                             </div>
                         </form>
                         <div class="loginButtonsBox">
                             <button class="loginButtons loginButtonUser" form="loginForm">Login</button>
-                            <button class="loginButtons loginButtonGuest" onclick="loginAsGuest()">Guest Login</button>
+                            <button type="button" class="loginButtons loginButtonGuest" onclick="loginAsGuest()">Guest Login</button>
                         </div>
                     </div>
                     <div class="signUpField-mobile d-none">
                         <span>Not a join user?</span>
-                        <button class="loginButtons signUpButton signUpButton-mobile" onclick="gotoSignUp()">Sign
+                        <button type="button" class="loginButtons signUpButton signUpButton-mobile" onclick="gotoSignUp()">Sign
                             up</button>
                     </div>
                 </div>
                 <div class="loginFooter">
-                    <div class="privacyPolicy" onclick="switchPageNewTab('privacy_external.html');" target="_blank">
+                    <a class="privacyPolicy" href="./privacy_external.html" target="_blank" rel="noopener noreferrer">
                         <span>Privacy policy</span>
-                    </div>
-                    <div class="legalNotice" onclick="switchPageNewTab('legal_notice_external.html');" target="_blank">
+                    </a>
+                    <a class="legalNotice" href="./legal_notice_external.html" target="_blank" rel="noopener noreferrer">
                         <span>Legal notice</span>
-                    </div>
+                    </a>
                 </div>
             </div>
         </main>

--- a/js/addTask.js
+++ b/js/addTask.js
@@ -218,9 +218,9 @@ function renderContactsToDropdown(){
         const safeContactId = toSafeInteger(contact && contact.id);
         const safeContactName = escapeHtml(contact && contact.name);
 
-        content.innerHTML += /*html*/`<div class="dropdownOption" id="assignedToContact${safeContactId}" marked=false onclick="assignContactToTask(${safeContactId})">
-            <div class="dropdownContactBadgeAndName">${renderAssignedToButtonsHTML(contact)} ${safeContactName}</div> <img src="./assets/img/icon-check_button_unchecked.png" alt="">
-            </div>`
+        content.innerHTML += /*html*/`<button type="button" class="dropdownOption" id="assignedToContact${safeContactId}" marked=false onclick="assignContactToTask(${safeContactId})">
+            <span class="dropdownContactBadgeAndName">${renderAssignedToButtonsHTML(contact)} ${safeContactName}</span> <img src="./assets/img/icon-check_button_unchecked.png" alt="">
+            </button>`
     })
 }
 
@@ -385,6 +385,10 @@ function activateButton(id, onClickFunctionName){
     if(document.getElementById(id)){
         let btn = document.getElementById(id);
         btn.classList.remove("disabled");
+        if (btn.tagName === "BUTTON") {
+            btn.disabled = false;
+            btn.setAttribute("aria-disabled", "false");
+        }
         btn.setAttribute("onclick", onClickFunctionName);
     }
 }
@@ -399,9 +403,10 @@ function deactivateButton(id){
     if(document.getElementById(id)){
         let btn = document.getElementById(id);
         btn.classList.add("disabled");
+        if (btn.tagName === "BUTTON") {
+            btn.disabled = true;
+            btn.setAttribute("aria-disabled", "true");
+        }
         btn.removeAttribute("onclick");
     }
 }
-
-
-

--- a/js/board.js
+++ b/js/board.js
@@ -437,7 +437,7 @@ function finalizeEdit() {
 function createEditHeader(){
     return /*html*/`
 <div class="boardEditTaskHeader">
-    <div class="boardAddTaskCloseHoverContainer" onclick="closeCard()"></div>
+    <button type="button" class="boardAddTaskCloseHoverContainer" onclick="closeCard()" aria-label="Close edit card"></button>
  </div>
     `
 }
@@ -454,10 +454,10 @@ function createEditFooter(task){
 
     return /*html*/`
     <div class="addTaskBodyRight">
-        <div class="createBtn addTaskBtn" onclick="saveEditedTask(${safeTaskId}); doNotClose(event)">
+        <button type="button" class="createBtn addTaskBtn" onclick="saveEditedTask(${safeTaskId}); doNotClose(event)">
             <span class="addTaskBtnText">Ok</span>
-            <div class="createBtnImg"></div>
-        </div>
+            <span class="createBtnImg"></span>
+        </button>
     </div>`
 }
 

--- a/summary.html
+++ b/summary.html
@@ -48,7 +48,7 @@
                             <div id="buttonContainer" class="button-container">
 
 
-                                <div class="urgentAndDate urgent" id="urgentAndDate" onclick="switchPage('board.html')">
+                                <a class="urgentAndDate urgent" id="urgentAndDate" href="./board.html">
                                     <div class="urgentBox">
                                         <div class="image-and-amount flex">
                                             <img src="./assets/img/icon-blue-urgent_clock-with-border.png"
@@ -62,9 +62,9 @@
                                         <div id="date" class="date"></div>
                                         <span>Upcoming Deadline</span>
                                     </div>
-                                </div>
+                                </a>
 
-                                <div class="square-button inBoard" onclick="switchPage('board.html')">
+                                <a class="square-button inBoard" href="./board.html">
                                     <div class="inner-square-button">
                                         <div class="image-and-amount flex">
                                             <img src="./assets/img/icon-blue-tasks_in_board.png" alt="file shelf">
@@ -72,10 +72,10 @@
                                         </div>
                                         <span>Tasks in Board</span>
                                     </div>
-                                </div>
+                                </a>
 
 
-                                <div id="toDoButton" class="square-button toDo" onclick="switchPage('board.html')">
+                                <a id="toDoButton" class="square-button toDo" href="./board.html">
                                     <div class="inner-square-button toDoInner">
                                         <div class="image-and-amount flex">
                                             <img src="./assets/img/icon-blue-todo.png" alt="todo list">
@@ -83,9 +83,9 @@
                                         </div>
                                         <span class="no-wrap">Tasks To-do</span>
                                     </div>
-                                </div>
+                                </a>
 
-                                <div class="square-button inProgress" onclick="switchPage('board.html')">
+                                <a class="square-button inProgress" href="./board.html">
                                     <div class="inner-square-button">
                                         <div class="image-and-amount flex">
                                             <img src="./assets/img/icon-blue-in_progress.png" alt="rising chart">
@@ -93,9 +93,9 @@
                                         </div>
                                         <span>Task in Progress</span>
                                     </div>
-                                </div>
+                                </a>
 
-                                <div class="square-button feedback" onclick="switchPage('board.html')">
+                                <a class="square-button feedback" href="./board.html">
                                     <div class="inner-square-button ">
                                         <div class="image-and-amount flex">
                                             <img src="./assets/img/icon-blue-awaiting_feedback.png" alt="feedback card">
@@ -103,9 +103,9 @@
                                         </div>
                                         <span>Awaiting Feedback</span>
                                     </div>
-                                </div>
+                                </a>
 
-                                <div class="square-button done" onclick="switchPage('board.html')">
+                                <a class="square-button done" href="./board.html">
                                     <div class="inner-square-button">
                                         <div class="image-and-amount flex">
                                             <img src="./assets/img/icon-blue-done.png" alt="thumbs up">
@@ -113,7 +113,7 @@
                                         </div>
                                         <span>Tasks Done</span>
                                     </div>
-                                </div>
+                                </a>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
This PR improves accessibility by replacing clickable non-semantic containers with semantic interactive elements (`button` / `a`) in key UI flows.

Closes #29.

## What changed
- Replaced clickable `div` controls with semantic controls on main pages:
  - `index.html`
  - `summary.html`
  - `board.html`
- Updated shared template rendering to use semantic controls in dynamic UI:
  - card actions
  - add-task actions
  - subtask actions
  - legal/privacy footer links
- Updated related JS behavior to work correctly with real buttons:
  - button enable/disable now also uses native `disabled` + `aria-disabled`
- Updated CSS to preserve current visual design after semantic conversion
  (button reset styles, icon wrappers, link text styling, etc.).

## Accessibility impact
- Native keyboard behavior now works without custom hacks:
  - Tab focus for controls
  - Enter/Space activation for buttons
- Better semantic structure for assistive technologies.

## Validation
- `node --check` passed for updated JS files.
- template duplicate-attribute guardrail passed (`npm run lint:templates`).
- visual behavior preserved for converted controls on affected pages.

## Notes
- Remaining `onclick` on a few non-control containers is intentional
  (event-propagation handling), not user-facing clickable controls.
