### PR TITLE
feat(a11y): add overlay and dropdown focus management

### DIFF
--- a/js/board_popups.js
+++ b/js/board_popups.js
@@ -4,6 +4,7 @@
  * @param {number} taskId - The ID of the task to open.
  */
 function openCard(taskId){
+    const opener = document.activeElement;
     if (!document.getElementById('openCardContainer')){
         let newDiv = document.createElement('div');
         setAttributes(newDiv, {
@@ -30,6 +31,16 @@ function openCard(taskId){
         renderOpenCardImages(task);
     }
     toggleBoardOverlay('closeCard()');
+    activateFocusLayer(openCardContainer, {
+        opener,
+        initialFocus: '.boardAddTaskCloseHoverContainer',
+        onEscape: () => {
+            if (typeof closeOpenDropdowns === "function" && closeOpenDropdowns({ restoreFocus: true })) {
+                return;
+            }
+            closeCard();
+        },
+    });
 }
 
 
@@ -39,6 +50,12 @@ function openCard(taskId){
  */
 async function closeCard(){
     let openCardContainer = document.getElementById('openCardContainer');
+    if (!openCardContainer) {
+        deactivateFocusLayer({ restoreFocus: true });
+        toggleBoardOverlay('disable');
+        return;
+    }
+    deactivateFocusLayer({ restoreFocus: true });
     openCardContainer.remove();
     openCardContainer.classList.add('d-none');
     openCardContainer.removeAttribute('editing');
@@ -87,6 +104,12 @@ function renderBoardAddTaskOverlay(){
     document.getElementById('addTaskBodyRight').innerHTML += renderAddTaskFooterHTML();
     setTodayDateAsMin();
     setPriority('medium');
+    if (typeof registerAddTaskKeyboardAccessibility === "function") {
+        registerAddTaskKeyboardAccessibility();
+    }
+    if (typeof initializeDropdownAccessibilityState === "function") {
+        initializeDropdownAccessibilityState();
+    }
     renderContactsToDropdown();
     checkValidity();
 }
@@ -97,6 +120,7 @@ function renderBoardAddTaskOverlay(){
  * If the container does not exist, it will be created and rendered.
  */
 function showAddTaskContainer(category='category-0') {
+    const opener = document.activeElement;
     newTask.category = category;
     if (!document.getElementById('addTaskHoverContainer')) {
         renderBoardAddTaskOverlay();
@@ -110,6 +134,16 @@ function showAddTaskContainer(category='category-0') {
     let container = document.getElementById('addTaskHoverContainer');
     container.classList.add('showBoard');
     toggleBoardOverlay("hideAddTaskContainer()");
+    activateFocusLayer(container, {
+        opener,
+        initialFocus: '.boardAddTaskCloseHoverContainer, #addTaskEnterTitleInput',
+        onEscape: () => {
+            if (typeof closeOpenDropdowns === "function" && closeOpenDropdowns({ restoreFocus: true })) {
+                return;
+            }
+            hideAddTaskContainer();
+        },
+    });
 }
 
 
@@ -118,8 +152,14 @@ function showAddTaskContainer(category='category-0') {
  *
  */
 function hideAddTaskContainer(){
+    if(!document.getElementById('addTaskHoverContainer')){
+        deactivateFocusLayer({ restoreFocus: true });
+        toggleBoardOverlay('disable');
+        return;
+    }
     if(document.getElementById('addTaskHoverContainer')){
         let container = document.getElementById('addTaskHoverContainer');
+        deactivateFocusLayer({ restoreFocus: true });
         container.classList.remove('showBoard');
         container.classList.add('hideBoard');
         toggleBoardOverlay('disable');

--- a/js/contact_popups.js
+++ b/js/contact_popups.js
@@ -47,6 +47,8 @@ async function saveContact() {
   }
 }
 
+let contactOverlayOpener = null;
+
 
 /**
  * Returns contact form element references from the current DOM.
@@ -209,11 +211,17 @@ function resetContactForm(formElements = getContactFormElements()) {
  * @returns {void}
  */
 function addContactCard() {
+  contactOverlayOpener = document.activeElement;
   if (!document.getElementById("addContact")) {
     renderAddContacts();
   }
   document.getElementById("addContact").innerHTML = renderAddContactsHTML();
   addOverlay("closeOverlay('addContact')");
+  activateFocusLayer("addContact", {
+    opener: contactOverlayOpener,
+    initialFocus: "#contactName",
+    onEscape: () => closeOverlay("addContact"),
+  });
 }
 
 
@@ -243,6 +251,7 @@ function addOverlay(functionToAdd) {
  * @return {void}
  */
 function closeOverlay(id) {
+  deactivateFocusLayer({ restoreFocus: true });
   const container = document.getElementById(id);
   if (!container) {
     return;
@@ -408,6 +417,7 @@ async function saveEditedContact(id) {
  * @return {void} This function does not return a value.
  */
 function editContactCard(contact) {
+  contactOverlayOpener = document.activeElement;
   if (!document.getElementById("editContact")) {
     renderEditContact();
   }
@@ -417,6 +427,11 @@ function editContactCard(contact) {
     contact.contactColor
   );
   addOverlay("closeOverlay('editContact')");
+  activateFocusLayer("editContact", {
+    opener: contactOverlayOpener,
+    initialFocus: "#contactName",
+    onEscape: () => closeOverlay("editContact"),
+  });
 }
 
 

--- a/js/helper.js
+++ b/js/helper.js
@@ -137,3 +137,285 @@ function sanitizeMailtoHref(value) {
   }
   return `mailto:${encodeURIComponent(singleLineValue)}`;
 }
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled]):not([type='hidden'])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])",
+].join(", ");
+
+let activeFocusLayer = null;
+
+/**
+ * Activates focus management for dialog-like containers.
+ * Traps Tab navigation, supports Esc callback, and restores focus on close.
+ *
+ * @param {HTMLElement|string} containerOrId - Focus scope container or element id.
+ * @param {Object} [options={}] - Focus behavior options.
+ * @param {HTMLElement|null} [options.opener] - Element that opened the container.
+ * @param {Function|null} [options.onEscape] - Called when Esc is pressed.
+ * @param {string|HTMLElement|null} [options.initialFocus] - Initial focus target.
+ * @returns {boolean} True if focus layer was activated.
+ */
+function activateFocusLayer(containerOrId, options = {}) {
+  const container = resolveFocusLayerContainer(containerOrId);
+  if (!container) {
+    return false;
+  }
+
+  deactivateFocusLayer({ restoreFocus: false });
+
+  const layer = {
+    container,
+    opener: options.opener || document.activeElement,
+    onEscape: typeof options.onEscape === "function" ? options.onEscape : null,
+    initialFocus: options.initialFocus || null,
+    outsideFocusRecords: [],
+    keydownHandler: null,
+    focusinHandler: null,
+  };
+
+  layer.outsideFocusRecords = lockOutsideFocusableElements(container);
+  layer.keydownHandler = (event) => handleFocusLayerKeydown(event, layer);
+  layer.focusinHandler = (event) => handleFocusLayerFocusin(event, layer);
+
+  document.addEventListener("keydown", layer.keydownHandler, true);
+  document.addEventListener("focusin", layer.focusinHandler, true);
+  activeFocusLayer = layer;
+
+  focusLayerInitialTarget(layer);
+  return true;
+}
+
+/**
+ * Deactivates active focus management layer.
+ *
+ * @param {Object} [options={}] - Deactivation options.
+ * @param {boolean} [options.restoreFocus=true] - Restore focus to opener.
+ * @returns {void}
+ */
+function deactivateFocusLayer(options = {}) {
+  if (!activeFocusLayer) {
+    return;
+  }
+
+  const { restoreFocus = true } = options;
+  const layer = activeFocusLayer;
+  activeFocusLayer = null;
+
+  document.removeEventListener("keydown", layer.keydownHandler, true);
+  document.removeEventListener("focusin", layer.focusinHandler, true);
+  restoreOutsideFocusableElements(layer.outsideFocusRecords);
+
+  if (restoreFocus) {
+    focusElementIfPossible(layer.opener);
+  }
+}
+
+/**
+ * Resolves container references for focus layer activation.
+ *
+ * @param {HTMLElement|string} containerOrId - Container reference.
+ * @returns {HTMLElement|null} Resolved container element.
+ */
+function resolveFocusLayerContainer(containerOrId) {
+  if (!containerOrId) {
+    return null;
+  }
+  if (typeof containerOrId === "string") {
+    return document.getElementById(containerOrId);
+  }
+  if (containerOrId instanceof HTMLElement) {
+    return containerOrId;
+  }
+  return null;
+}
+
+/**
+ * Handles keyboard behavior for the active focus layer.
+ *
+ * @param {KeyboardEvent} event - Keyboard event.
+ * @param {Object} layer - Active focus layer data.
+ * @returns {void}
+ */
+function handleFocusLayerKeydown(event, layer) {
+  if (activeFocusLayer !== layer || !layer.container.isConnected) {
+    return;
+  }
+
+  if (event.key === "Escape" && layer.onEscape) {
+    event.preventDefault();
+    event.stopPropagation();
+    layer.onEscape();
+    return;
+  }
+
+  if (event.key !== "Tab") {
+    return;
+  }
+
+  const focusableElements = getFocusableElements(layer.container);
+  if (focusableElements.length === 0) {
+    event.preventDefault();
+    focusElementIfPossible(layer.container);
+    return;
+  }
+
+  const first = focusableElements[0];
+  const last = focusableElements[focusableElements.length - 1];
+  const activeElement = document.activeElement;
+
+  if (event.shiftKey) {
+    if (activeElement === first || !layer.container.contains(activeElement)) {
+      event.preventDefault();
+      focusElementIfPossible(last);
+    }
+    return;
+  }
+
+  if (activeElement === last || !layer.container.contains(activeElement)) {
+    event.preventDefault();
+    focusElementIfPossible(first);
+  }
+}
+
+/**
+ * Ensures focus cannot leave active layer container.
+ *
+ * @param {FocusEvent} event - Focus event.
+ * @param {Object} layer - Active focus layer data.
+ * @returns {void}
+ */
+function handleFocusLayerFocusin(event, layer) {
+  if (activeFocusLayer !== layer || !layer.container.isConnected) {
+    return;
+  }
+
+  if (layer.container.contains(event.target)) {
+    return;
+  }
+
+  const fallbackTarget = getFocusableElements(layer.container)[0] || layer.container;
+  focusElementIfPossible(fallbackTarget);
+}
+
+/**
+ * Applies initial focus when a layer opens.
+ *
+ * @param {Object} layer - Active focus layer data.
+ * @returns {void}
+ */
+function focusLayerInitialTarget(layer) {
+  const { container, initialFocus } = layer;
+  let initialTarget = null;
+
+  if (typeof initialFocus === "string" && initialFocus.trim() !== "") {
+    initialTarget = container.querySelector(initialFocus);
+  } else if (initialFocus instanceof HTMLElement) {
+    initialTarget = initialFocus;
+  }
+
+  if (!initialTarget) {
+    initialTarget = getFocusableElements(container)[0] || container;
+  }
+
+  if (!initialTarget.hasAttribute("tabindex") && initialTarget === container) {
+    initialTarget.setAttribute("tabindex", "-1");
+  }
+
+  focusElementIfPossible(initialTarget);
+}
+
+/**
+ * Returns focusable descendants inside a given container.
+ *
+ * @param {HTMLElement} container - Scope container.
+ * @returns {HTMLElement[]} Focusable elements.
+ */
+function getFocusableElements(container) {
+  return Array.from(container.querySelectorAll(FOCUSABLE_SELECTOR)).filter(
+    (element) =>
+      element instanceof HTMLElement &&
+      !element.hasAttribute("disabled") &&
+      isElementVisibleForFocus(element)
+  );
+}
+
+/**
+ * Checks whether an element is visible enough to receive focus.
+ *
+ * @param {HTMLElement} element - Candidate element.
+ * @returns {boolean} True when visible.
+ */
+function isElementVisibleForFocus(element) {
+  return (
+    element.getClientRects().length > 0 &&
+    getComputedStyle(element).visibility !== "hidden"
+  );
+}
+
+/**
+ * Focuses an element when possible.
+ *
+ * @param {HTMLElement|null} element - Focus target.
+ * @returns {boolean} True when focus call was attempted.
+ */
+function focusElementIfPossible(element) {
+  if (!(element instanceof HTMLElement) || !element.isConnected) {
+    return false;
+  }
+  try {
+    element.focus();
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+/**
+ * Removes all outside elements from tab-order while overlay is active.
+ *
+ * @param {HTMLElement} container - Active focus layer container.
+ * @returns {Array<{element: HTMLElement, tabindex: string|null}>} Stored tabindex records.
+ */
+function lockOutsideFocusableElements(container) {
+  const allFocusable = Array.from(document.querySelectorAll(FOCUSABLE_SELECTOR));
+  const records = [];
+
+  allFocusable.forEach((element) => {
+    if (!(element instanceof HTMLElement)) {
+      return;
+    }
+    if (container.contains(element)) {
+      return;
+    }
+    records.push({ element, tabindex: element.getAttribute("tabindex") });
+    element.setAttribute("tabindex", "-1");
+  });
+
+  return records;
+}
+
+/**
+ * Restores tabindex values for elements changed by lockOutsideFocusableElements.
+ *
+ * @param {Array<{element: HTMLElement, tabindex: string|null}>} records - Stored tabindex records.
+ * @returns {void}
+ */
+function restoreOutsideFocusableElements(records) {
+  records.forEach(({ element, tabindex }) => {
+    if (!(element instanceof HTMLElement) || !element.isConnected) {
+      return;
+    }
+
+    if (tabindex === null) {
+      element.removeAttribute("tabindex");
+      return;
+    }
+
+    element.setAttribute("tabindex", tabindex);
+  });
+}


### PR DESCRIPTION
## Summary
This PR implements accessibility-focused keyboard and focus management for dialog-like overlays and dropdown flows.

Closes #30.

## What changed

### 1) Shared focus-layer utility
- Added reusable focus management helpers in `js/helper.js`:
  - Focus trap inside active overlay
  - `Esc` handling via callback
  - Focus restore to opener on close
  - Temporary tab-order lock for background interactive elements

### 2) Board overlays
- Applied focus management to:
  - Task details overlay (`openCard` / `closeCard`)
  - Board add-task overlay (`showAddTaskContainer` / `hideAddTaskContainer`)
- `Esc` closes open dropdowns first, then closes the overlay.
- Added guards for missing containers to avoid runtime errors.

### 3) Contacts overlays
- Applied focus management to:
  - Add contact overlay
  - Edit contact overlay
- Focus now moves to first input on open and returns to opener on close.
- `Esc` closes the active contact overlay.

### 4) Add-task dropdown flow
- Refactored dropdown open/close handling into explicit functions.
- Added keyboard behavior:
  - `Esc` closes active dropdown(s)
  - Focus returns to the dropdown trigger
- Added ARIA state updates (`aria-expanded`, `aria-haspopup`).
- Added null guards and deterministic close behavior.

## Acceptance criteria mapping
- Focus is trapped inside active overlays/dialog-like containers: ✅
- `Esc` closes closable overlays/dropdowns: ✅
- Focus returns to opener after close: ✅
- Background interactive elements are not focusable while overlay is active: ✅

## Validation
- `node --check js/helper.js js/board_popups.js js/contact_popups.js js/addTask.js` ✅
- `npm run lint:templates` ✅
- `npm run lint:js` ⚠️ requires local ESLint install in this environment
