### PR TITLE
feat(a11y): add form labels and aria names for icon actions

### DIFF
--- a/addTask.html
+++ b/addTask.html
@@ -7,6 +7,7 @@
   
   <!-- Stylesheets -->
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="./assets/css/accessibility.css">
   <link rel="stylesheet" href="assets/css/header.css">
   <link rel="stylesheet" href="assets/css/navigation.css">
   <link rel="stylesheet" href="assets/css/contacts.css">

--- a/assets/css/accessibility.css
+++ b/assets/css/accessibility.css
@@ -1,0 +1,17 @@
+.sr-only {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
+button.arrowLeft {
+  border: none;
+  background: transparent;
+  padding: 0;
+}

--- a/assets/css/contacts.css
+++ b/assets/css/contacts.css
@@ -93,6 +93,13 @@
   background-color: #005dff;
 }
 
+.icon-action-button {
+  border: none;
+  background: transparent;
+  padding: 0;
+  cursor: pointer;
+}
+
 .add-contact-header-close img {
   cursor: pointer;
 }
@@ -694,6 +701,9 @@ input::placeholder {
   align-items: center;
   justify-content: center;
   cursor: pointer;
+  border: none;
+  background: transparent;
+  padding: 0;
 }
 
 .editDelete {
@@ -706,6 +716,9 @@ input::placeholder {
 
 .add-contact-button {
   display: none;
+  border: none;
+  background: transparent;
+  padding: 0;
 }
 
 @media screen and (max-width: 1199px) {
@@ -841,6 +854,9 @@ input::placeholder {
   .contact-details-back-button {
     display: flex;
     cursor: pointer;
+    border: none;
+    background: transparent;
+    padding: 0;
   }
 
   .contact-details-back-button :hover {

--- a/assets/templates/html_templates.js
+++ b/assets/templates/html_templates.js
@@ -215,12 +215,14 @@ function renderLoginPageHTML() {
                 <form onsubmit="loginUser(); return false;">
                     <div class=" innerLoginBox">
                         <div class="loginEmailBox">
-                            <input type="email" id="loginEmailInput" placeholder="Email" required>
+                            <label class="sr-only" for="loginEmailInput">Email</label>
+                            <input type="email" id="loginEmailInput" placeholder="Email" autocomplete="email" required>
                             <div class="mailIcon"><img src="./assets/img/icon-mail.png" alt="letter"></div>
                         </div>
 
                         <div class="loginPasswordBox">
-                            <input type="password" id="loginPasswordInput" placeholder="Password" required>
+                            <label class="sr-only" for="loginPasswordInput">Password</label>
+                            <input type="password" id="loginPasswordInput" placeholder="Password" autocomplete="current-password" required>
                             <div class="mailIcon"><img src="./assets/img/icon-lock.png" alt="lock"></div>
                         </div>
                     </div>
@@ -267,7 +269,7 @@ function renderSignUpPageHTML() {
         </header>
         <div class="signUp-page">
             <div class="signUp-box">
-                <div class="arrowLeft"><img src="./assets/img/icon-arrow_left.png" alt="arrow left"></div>
+                <button type="button" class="arrowLeft" onclick="redirectToLogin()" aria-label="Back to login"><img src="./assets/img/icon-arrow_left.png" alt="arrow left"></button>
 
                 <div class="h1SignUpBox">
                     <h1 class="signUpH1">Sign up</h1>
@@ -278,12 +280,14 @@ function renderSignUpPageHTML() {
                     <form onsubmit="addUser(); return false">
                         <div class="innerSignUpBox">
                             <div class="signUpEmailBox">
-                                <input type="email" id="signUpEmailInput" placeholder="Email" required>
+                                <label class="sr-only" for="signUpEmailInput">Email</label>
+                                <input type="email" id="signUpEmailInput" placeholder="Email" autocomplete="email" required>
                                 <div class="mailIcon"><img src="./assets/img/icon-mail.png" alt="letter"></div>
                             </div>
 
                             <div class="signUpPasswordBox">
-                                <input type="password" id="signUpPasswordInput" placeholder="Password" required>
+                                <label class="sr-only" for="signUpPasswordInput">Password</label>
+                                <input type="password" id="signUpPasswordInput" placeholder="Password" autocomplete="new-password" required>
                                 <div class="mailIcon"><img src="./assets/img/icon-lock.png" alt="lock"></div>
                             </div>
                         </div>
@@ -336,13 +340,15 @@ function renderAddTaskMainContentHTML() {
   return /*html*/ `<div class="addTaskBodyLeft">
         <div class="addTaskBodyTop">
             <div class="addTaskAddTitleContainer">
-                <input type="text" id="addTaskEnterTitleInput" placeholder="Enter a title" required>
-                <div class="addTaskRequired" id="requiredTitle"></div>
+                <label class="sr-only" for="addTaskEnterTitleInput">Task title</label>
+                <input type="text" id="addTaskEnterTitleInput" placeholder="Enter a title" aria-describedby="requiredTitle" aria-invalid="false" required>
+                <div class="addTaskRequired" id="requiredTitle" role="alert" aria-live="polite"></div>
             </div>
             <div class="addTaskDescription">
                 <div class="addTaskTitles"><span class="bold">Description</span> (optional)</div>
                 <div>
                 <div class="textAreaContainer">
+                    <label class="sr-only" for="addTaskDescriptionInput">Task description</label>
                     <textarea id="addTaskDescriptionInput" type="text" placeholder="Enter a description"></textarea>
                 </div>
             </div>
@@ -351,10 +357,11 @@ function renderAddTaskMainContentHTML() {
                 <div class="addTaskTitles"><span class="bold">Due date</span></div>
                 <div>
                     <div class="addTaskDueDateInputContainer border-bottom pointer" id="addTaskDueDateInputContainer">
-                        <input class="addTaskDueDateInput" id="addTaskDueDateInput" type="date"  value="">
+                        <label class="sr-only" for="addTaskDueDateInput">Due date</label>
+                        <input class="addTaskDueDateInput" id="addTaskDueDateInput" type="date" aria-describedby="requiredDueDate" aria-invalid="false" value="">
                         <button type="button" class="addTaskDueDateImage" onclick="addTaskDueDateOpenCalendear()" aria-label="Open due date picker"></button>
                     </div>
-                    <div class="addTaskRequired" id="requiredDueDate"></div>
+                    <div class="addTaskRequired" id="requiredDueDate" role="alert" aria-live="polite"></div>
                 </div>
             </div>
         </div>
@@ -510,10 +517,11 @@ function editSubtaskHTML(subtask) {
   const safeSubtaskText = escapeHtml(subtask && subtask.subtaskText);
 
   return /*html*/ `
+        <label class="sr-only" for="subtaskEditInputField">Edit subtask</label>
         <input type="text" id="subtaskEditInputField" value="${safeSubtaskText}">
         <div class="subtaskCheckboxes">
-        <button type="button" class="subtaskImgDiv pointer" id="subtaskImgDelete" onclick="deleteSubtask(${safeSubtaskId})"></button><div class="vLine"></div>
-            <button type="button" class="subtaskImgDiv pointer" id="subtaskImgAddCheck" onclick="saveEditSubtask(${safeSubtaskId})"></button>
+        <button type="button" class="subtaskImgDiv pointer" id="subtaskImgDelete" onclick="deleteSubtask(${safeSubtaskId})" aria-label="Delete subtask"></button><div class="vLine"></div>
+            <button type="button" class="subtaskImgDiv pointer" id="subtaskImgAddCheck" onclick="saveEditSubtask(${safeSubtaskId})" aria-label="Save subtask"></button>
         </div>`;
 }
 
@@ -529,11 +537,12 @@ function editSubtaskHTML(subtask) {
  */
 function renderSubtaskInputFieldHTML() {
   return /*html*/ `
+     <label class="sr-only" for="subtaskInputField">Subtask</label>
      <input type="text" id="subtaskInputField" placeholder="Add new subtask" onclick="doNotClose(event)">
      <div class="subtaskAddOrCancel">
-         <button type="button" id="subtaskImgAddCheck" class="subtaskImgDiv pointer" onclick="subtaskAddOrCancel('add'); doNotClose(event)"></button>
+         <button type="button" id="subtaskImgAddCheck" class="subtaskImgDiv pointer" onclick="subtaskAddOrCancel('add'); doNotClose(event)" aria-label="Add subtask"></button>
          <div class="vLine"></div>
-         <button type="button" id="subtaskImgAddCancel" class="subtaskImgDiv pointer" onclick="subtaskAddOrCancel('cancel'); doNotClose(event)"></button>
+         <button type="button" id="subtaskImgAddCancel" class="subtaskImgDiv pointer" onclick="subtaskAddOrCancel('cancel'); doNotClose(event)" aria-label="Cancel subtask input"></button>
      </div>`;
 }
 
@@ -556,9 +565,9 @@ function renderSubtaskHTML(outputContainer, subtask) {
         <div class="subTaskOutputDiv" id="subtask${safeSubtaskId}" ondblclick="editSubtask(${safeSubtaskId})">
         <div class="subtaskText">${safeSubtaskText}</div>
             <div class="subtaskCheckboxes">
-                <button type="button" class="subtaskImgDiv pointer" id="subtaskImgEdit" onclick="editSubtask(${safeSubtaskId})"></button>
+                <button type="button" class="subtaskImgDiv pointer" id="subtaskImgEdit" onclick="editSubtask(${safeSubtaskId})" aria-label="Edit subtask"></button>
                 <div class="vLine"></div>
-                <button type="button" class="subtaskImgDiv pointer" id="subtaskImgDelete" onclick="deleteSubtask(${safeSubtaskId})"></button>
+                <button type="button" class="subtaskImgDiv pointer" id="subtaskImgDelete" onclick="deleteSubtask(${safeSubtaskId})" aria-label="Delete subtask"></button>
             </div>
         </div>`;
 }

--- a/board.html
+++ b/board.html
@@ -7,6 +7,7 @@
     <link rel="shortcut icon" href="./assets/img/favicon.png" type="image/png">
 
     <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="./assets/css/accessibility.css">
     <link rel="stylesheet" href="assets/css/header.css" />
     <link rel="stylesheet" href="assets/css/navigation.css" />
     <link rel="stylesheet" href="./assets/css/contacts.css">

--- a/contacts.html
+++ b/contacts.html
@@ -7,6 +7,7 @@
     <link rel="shortcut icon" href="./assets/img/favicon.png" type="image/png">
 
     <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="./assets/css/accessibility.css">
     <link rel="stylesheet" href="assets/css/header.css" />
     <link rel="stylesheet" href="assets/css/navigation.css" />
     <link rel="stylesheet" href="./assets/css/contacts.css">

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link rel="shortcut icon" href="./assets/img/favicon.png" type="image/png">
 
     <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="./assets/css/accessibility.css">
     <link rel="stylesheet" href="assets/css/header.css" />
     <link rel="stylesheet" href="assets/css/navigation.css" />
     <link rel="stylesheet" href="./assets/css/signUp.css">
@@ -45,12 +46,14 @@
                         <form id="loginForm" onsubmit="loginUser(); return false;">
                             <div class="innerLoginBox">
                                 <div class="loginInputField">
-                                    <input type="email" id="loginEmailInput" placeholder="Email" required="">
+                                    <label class="sr-only" for="loginEmailInput">Email</label>
+                                    <input type="email" id="loginEmailInput" placeholder="Email" autocomplete="email" required="">
                                     <div class="mailIcon"><img src="./assets/img/icon-mail.png" alt="letter">
                                     </div>
                                 </div>
                                 <div class="loginInputField">
-                                    <input type="password" id="loginPasswordInput" placeholder="Password" required="">
+                                    <label class="sr-only" for="loginPasswordInput">Password</label>
+                                    <input type="password" id="loginPasswordInput" placeholder="Password" autocomplete="current-password" required="">
                                     <div class="mailIcon"><img src="./assets/img/icon-lock.png" alt="lock">
                                     </div>
                                 </div>

--- a/js/addTask_tasks.js
+++ b/js/addTask_tasks.js
@@ -320,15 +320,26 @@ function setPriorityForNewCard(priority){
 function toggleRequiredMessage(requiredInputField){
     let requiredMessageField = document.getElementById(requiredInputField.requiredFieldId);
     let toUnderline = document.getElementById(requiredInputField.idForRedUnderline);
+    let inputField = document.getElementById(requiredInputField.id);
+
+    if (inputField) {
+        inputField.setAttribute('aria-describedby', requiredInputField.requiredFieldId);
+    }
 
     if (getStateOfRequriredField(requiredInputField)){
         requiredInputField.state = true;
         toUnderline.classList.remove('is-invalid');
-        requiredMessageField.innerHTML = "";
+        if (inputField) {
+            inputField.setAttribute('aria-invalid', 'false');
+        }
+        requiredMessageField.textContent = "";
     } else {
         requiredInputField.state = false;
         toUnderline.classList.add('is-invalid');
-        requiredMessageField.innerHTML = "This field is requried";
+        if (inputField) {
+            inputField.setAttribute('aria-invalid', 'true');
+        }
+        requiredMessageField.textContent = "This field is required";
     }
     setCreateBtnState();
 }

--- a/js/board.js
+++ b/js/board.js
@@ -567,6 +567,7 @@ function renderTaskImages(task) {
     const btn = document.createElement('button');
     btn.textContent = 'X'; 
     btn.className = 'delete-edit-thumbnail';
+    btn.setAttribute('aria-label', 'Delete attachment');
     btn.addEventListener('click', e => { 
       e.stopPropagation(); 
       task.images.splice(index, 1); 

--- a/js/contacts_render.js
+++ b/js/contacts_render.js
@@ -14,9 +14,9 @@ function generateContactsContainerHTML() {
       <div id="addContactContainer" class="hidden">
       </div>
   </div>
-  <div class="add-contact-button" onclick="addContactCard()">
+  <button type="button" class="add-contact-button" onclick="addContactCard()" aria-label="Add new contact">
     <img src="./assets/img/Secondary mobile contact V1.png" alt="">
-  </div>
+  </button>
   <div class="contacts-container-outer">
     <div class="contacts-container" id="contacts-container"> 
             <div id="button-add-contact-card" class="button-add-contact" onclick="addContactCard(); doNotClose(event)">
@@ -42,7 +42,9 @@ function renderAddContactsHTML() {
     return /*html*/ `
           <div class="add-contact-header">
               <div class="add-contact-header-close">
-                  <img onclick="closeOverlay('addContact')" src="./assets/img/icon-close_white.png" alt="closeAddContact">
+                  <button type="button" class="icon-action-button" onclick="closeOverlay('addContact')" aria-label="Close add contact form">
+                      <img src="./assets/img/icon-close_white.png" alt="">
+                  </button>
               </div>
           </div>
           <div class="add-contact-header-logo">
@@ -58,23 +60,26 @@ function renderAddContactsHTML() {
               </div>
               <form onsubmit="saveContact(); return false" class="add-contact-input-group">
                   <div class="input-frame">
-                      <input id="contactName" type="text" placeholder="Name" autofocus required>
+                      <label class="sr-only" for="contactName">Name</label>
+                      <input id="contactName" type="text" placeholder="Name" autocomplete="name" autofocus required>
                       <img src="./assets/img/icon-person.png" alt="">
                   </div>
                   <div class="input-frame">
-                      <input id="contactMail" type="email" placeholder="Email" autofocus required>
+                      <label class="sr-only" for="contactMail">Email</label>
+                      <input id="contactMail" type="email" placeholder="Email" autocomplete="email" autofocus required>
                       <img src="./assets/img/icon-mail.png" alt="">
                   </div>
                   <div class="input-frame">
-                      <input id="contactPhone" pattern="[0-9]*" type="tel" placeholder="Phone" autofocus required>
+                      <label class="sr-only" for="contactPhone">Phone</label>
+                      <input id="contactPhone" pattern="[0-9]*" type="tel" placeholder="Phone" autocomplete="tel" autofocus required>
                       <img src="./assets/img/icon-call.png" alt="">
                   </div>
                   <div id="addContactButton" class="addContactButton">
-                      <button class="cancelButton" onclick="closeOverlay('addContact')" onmouseover="changeCancelIcon()"
+                      <button type="button" class="cancelButton" onclick="closeOverlay('addContact')" onmouseover="changeCancelIcon()"
                           onmouseout="restoreCancelIcon()">Cancel
                           <img id="cancelIcon" src="./assets/img/icon-cancel.png" alt="">
                       </button>
-                      <button id="createBtn" class="createButton">Create contact
+                      <button type="submit" id="createBtn" class="createButton">Create contact
                           <img id="createIcon" src="./assets/img/icon-check.png" alt="">
                       </button>
                   </div>
@@ -97,7 +102,9 @@ function renderEditContactHTML(id, name, contactColor) {
     return /*html*/ `
           <div class="edit-contact-header">
               <div class="edit-contact-header-close">
-                  <img onclick="closeOverlay('editContact')" src="./assets/img/icon-close_white.png" alt="closeAddContact">
+                  <button type="button" class="icon-action-button" onclick="closeOverlay('editContact')" aria-label="Close edit contact form">
+                      <img src="./assets/img/icon-close_white.png" alt="">
+                  </button>
               </div>
           </div>
           <div class="edit-contact-header-logo">
@@ -116,19 +123,22 @@ function renderEditContactHTML(id, name, contactColor) {
               </div>
               <form action="" onsubmit="saveEditedContact(${safeContactId}); return false" class="add-contact-input-group">
                   <div class="input-frame">
-                      <input id="contactName" type="text" placeholder="Name" autofocus required>
+                      <label class="sr-only" for="contactName">Name</label>
+                      <input id="contactName" type="text" placeholder="Name" autocomplete="name" autofocus required>
                       <img src="./assets/img/icon-person.png" alt="">
                   </div>
                   <div class="input-frame">
-                      <input id="contactMail" type="email" placeholder="Email" autofocus required>
+                      <label class="sr-only" for="contactMail">Email</label>
+                      <input id="contactMail" type="email" placeholder="Email" autocomplete="email" autofocus required>
                       <img src="./assets/img/icon-mail.png" alt="">
                   </div>
                   <div class="input-frame">
-                      <input id="contactPhone" type="tel" placeholder="Phone" autofocus required>
+                      <label class="sr-only" for="contactPhone">Phone</label>
+                      <input id="contactPhone" type="tel" placeholder="Phone" autocomplete="tel" autofocus required>
                       <img src="./assets/img/icon-call.png" alt="">
                   </div>
                   <div id="addContactButton" class="addContactButton">
-                      <button class="cancelButton" onclick="closeOverlay('editContact')" onmouseover="changeCancelIcon()"
+                      <button type="button" class="cancelButton" onclick="closeOverlay('editContact')" onmouseover="changeCancelIcon()"
                           onmouseout="restoreCancelIcon()">Cancel
                           <img id="cancelIcon" src="./assets/img/icon-cancel.png" alt="">
                       </button>
@@ -200,9 +210,9 @@ function generateContactDetailsHTML(name, email, phone, id, color) {
       <div class="contact-Details">
         <div class="contact-details-header-and-button">
           <div class="contact-details-header-responsive">Contact Information</div>
-          <div class="contact-details-back-button" onclick="openContactDetails(${safeContactId})">
+          <button type="button" class="contact-details-back-button" onclick="openContactDetails(${safeContactId})" aria-label="Back to contact list">
             <img src="./assets/img/icon-arrow_left.png">
-          </div>
+          </button>
         </div>
         <div class="contact-details-header" id="contactDetailsHeader">
           <div class="contact-details-badge-group">
@@ -234,9 +244,9 @@ function generateContactDetailsHTML(name, email, phone, id, color) {
             <div class="contact-phone-container-phone">${safePhone}</div>
           </div>
         </div>
-        <div class="openEditDeleteResponsive" id="openEditDeleteResponsive" onclick="openEditDelete(); doNotClose(event)">
+        <button type="button" class="openEditDeleteResponsive" id="openEditDeleteResponsive" onclick="openEditDelete(); doNotClose(event)" aria-label="Open contact actions menu">
           <img src="./assets/img/Menu Contact options.png" alt="">
-        </div>
+        </button>
         <div class="editDelete d-none" id="editDelete" onclick="doNotClose(event)">
           <div class="editDiv" onclick="editContact(${safeContactId})">
             <img src="./assets/img/icon-edit.png" alt="">

--- a/js/signUp.js
+++ b/js/signUp.js
@@ -158,6 +158,15 @@ function showError(inputElement, message) {
       errorEl.className = 'error-message';
       container.parentNode.insertBefore(errorEl, container.nextSibling);
   }
+  if (!errorEl.id && inputElement.id) {
+      errorEl.id = `${inputElement.id}Error`;
+  }
+  errorEl.setAttribute('role', 'alert');
+  errorEl.setAttribute('aria-live', 'polite');
+  if (errorEl.id) {
+      inputElement.setAttribute('aria-describedby', errorEl.id);
+  }
+  inputElement.setAttribute('aria-invalid', 'true');
   errorEl.textContent = message;
   inputElement.classList.add('error');
 }
@@ -167,7 +176,11 @@ function clearError(inputElement) {
   let errorEl = container.nextElementSibling;
   if (errorEl && errorEl.classList.contains('error-message')) {
       errorEl.textContent = '';
+      if (errorEl.id) {
+          inputElement.setAttribute('aria-describedby', errorEl.id);
+      }
   }
+  inputElement.setAttribute('aria-invalid', 'false');
   inputElement.classList.remove('error');
 }
 

--- a/signUp.html
+++ b/signUp.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="shortcut icon" href="./assets/img/favicon.png" type="image/png">
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="./assets/css/accessibility.css">
   <link rel="stylesheet" href="assets/css/header.css" />
   <link rel="stylesheet" href="assets/css/navigation.css" />
   <link rel="stylesheet" href="./assets/css/signUp.css">
@@ -25,9 +26,9 @@
             <img class="signUpLogo" src="./assets/img/logo-medium_white.png" alt="logo">
           </header>
           <div class="signUp-box">
-            <div class="arrowLeft" onclick="redirectToLogin()">
+            <button type="button" class="arrowLeft" onclick="redirectToLogin()" aria-label="Back to login">
               <img src="./assets/img/icon-arrow_left.png" alt="arrow left">
-            </div>
+            </button>
             <div class="h1SignUpBox">
               <h1 class="signUpH1">Sign up</h1>
               <div class="horizontalH1UnderlineSignUp"></div>
@@ -37,46 +38,50 @@
                 <!-- Wrapper für Name-Feld -->
                 <div class="input-wrapper">
                   <div class="signUpInputField">
-                    <input type="text" id="signUpNameInput" placeholder="Name" onkeyup="checkIfFormIsValid()" required>
+                    <label class="sr-only" for="signUpNameInput">Name</label>
+                    <input type="text" id="signUpNameInput" placeholder="Name" aria-describedby="signUpNameError" aria-invalid="false" autocomplete="name" onkeyup="checkIfFormIsValid()" required>
                     <div class="mailIcon">
                       <img src="./assets/img/icon-person.png" alt="letter">
                     </div>
                   </div>
                   <!-- Fehlermeldung wird hier platziert -->
-                  <span class="error-message"></span>
+                  <span id="signUpNameError" class="error-message" aria-live="polite"></span>
                 </div>
 
                 <!-- Wrapper für E-Mail-Feld -->
                 <div class="input-wrapper">
                   <div class="signUpInputField">
-                    <input type="email" id="signUpEmailInput" placeholder="Email" onkeyup="checkIfFormIsValid()" required>
+                    <label class="sr-only" for="signUpEmailInput">Email</label>
+                    <input type="email" id="signUpEmailInput" placeholder="Email" aria-describedby="signUpEmailError" aria-invalid="false" autocomplete="email" onkeyup="checkIfFormIsValid()" required>
                     <div class="mailIcon">
                       <img src="./assets/img/icon-mail.png" alt="letter">
                     </div>
                   </div>
-                  <span class="error-message"></span>
+                  <span id="signUpEmailError" class="error-message" aria-live="polite"></span>
                 </div>
 
                 <!-- Wrapper für Passwort-Feld -->
                 <div class="input-wrapper">
                   <div class="signUpInputField">
-                    <input type="password" id="signUpPasswordInput" placeholder="Password" onkeyup="checkIfFormIsValid()" required>
+                    <label class="sr-only" for="signUpPasswordInput">Password</label>
+                    <input type="password" id="signUpPasswordInput" placeholder="Password" aria-describedby="signUpPasswordError" aria-invalid="false" autocomplete="new-password" onkeyup="checkIfFormIsValid()" required>
                     <div class="mailIcon">
                       <img src="./assets/img/icon-lock.png" alt="lock">
                     </div>
                   </div>
-                  <span class="error-message"></span>
+                  <span id="signUpPasswordError" class="error-message" aria-live="polite"></span>
                 </div>
 
                 <!-- Wrapper für Passwort-Bestätigung -->
                 <div class="input-wrapper">
                   <div class="signUpInputField">
-                    <input type="password" id="signUpPasswordInputConfirm" placeholder="Confirm Password" onkeyup="checkIfFormIsValid()" required>
+                    <label class="sr-only" for="signUpPasswordInputConfirm">Confirm password</label>
+                    <input type="password" id="signUpPasswordInputConfirm" placeholder="Confirm Password" aria-describedby="signUpPasswordConfirmError" aria-invalid="false" autocomplete="new-password" onkeyup="checkIfFormIsValid()" required>
                     <div class="mailIcon">
                       <img src="./assets/img/icon-lock.png" alt="lock">
                     </div>
                   </div>
-                  <span class="error-message"></span>
+                  <span id="signUpPasswordConfirmError" class="error-message" aria-live="polite"></span>
                 </div>
 
                 <!-- Checkbox für Privacy Policy -->


### PR DESCRIPTION
## Summary
This PR improves accessibility across auth, add-task, and contacts flows by adding explicit input labels, accessible names for icon-only controls, and better screen-reader support for validation feedback.

Closes #31.

## What changed
- Added a shared accessibility stylesheet (`assets/css/accessibility.css`) with a reusable `.sr-only` helper.
- Added explicit labels (screen-reader-only) for form inputs in:
  - login
  - signup
  - add-task
  - contact create/edit forms
- Added meaningful `aria-label` values for icon-only actions (close/back/menu and attachment delete).
- Connected validation messages to inputs using `aria-describedby`.
- Added `aria-invalid` updates for required add-task and signup validation flows.
- Marked required message containers as live regions for assistive technologies (`role="alert"`, `aria-live="polite"`).

## Validation
- `node --check js/signUp.js js/contacts_render.js js/addTask_tasks.js js/board.js assets/templates/html_templates.js` ✅
- `npm run lint:templates` ✅
- `npm run lint:js` ⚠️ fails locally because ESLint is not installed in this environment

## Notes
- Existing unrelated local changes (e.g. `style.css`, `assets/css/signUp.css`, local draft files) were not included in this commit.
