### PR TITLE
refactor(ui): migrate inline handlers to delegated event architecture

### DIFF
--- a/addTask.html
+++ b/addTask.html
@@ -37,7 +37,7 @@
 
   <title>Join - AddTask</title>
 </head>
-<body onload="addTaskInit()">
+<body data-init="addTaskInit">
   <div id="bodyContent" class="bodyContent">
     <header w3-include-html="./assets/templates/header.html" id="header" class="header">
     </header>

--- a/assets/templates/header.html
+++ b/assets/templates/header.html
@@ -1,22 +1,22 @@
 <div class="header-content header-mobile">
   <img class="header-logo" src="./assets/img/logo-small_white.png" alt="join-logo"
-    onclick="switchPage('summary.html')" />
+    data-action="switch-page" data-url="summary.html" />
   <div class="header-inner-right">
     <span class="header-kanban-writing">Kanban Project Management Tool</span>
-    <img id="helpIcon" class="helpIcon" src="./assets/img/icon-help.png" alt="help" onclick="openHelp()" />
-    <button id="userInitials" class="header-initials-button" onclick="openSmallMenu()">
+    <img id="helpIcon" class="helpIcon" src="./assets/img/icon-help.png" alt="help" data-action="open-help" />
+    <button id="userInitials" class="header-initials-button" data-action="open-small-menu">
     </button>
   </div>
   <div id="smallMenu" class="small-menu d-none">
     <a href="./privacy.html" class="smallMenuLink">Privacy Policy</a>
     <a href="./legal_notice.html" class="smallMenuLink">Legal Notice</a>
-    <a class="smallMenuLink" onclick="logout()">Log out</a>
+    <a href="#" class="smallMenuLink" data-action="logout" data-prevent-default="true">Log out</a>
   </div>
   <div id="smallMenuMobile" class="small-menu-mobile d-none">
     <a href="./help.html" class="smallMenuLink">Help</a>
     <a href="./privacy.html" class="smallMenuLink">Privacy Policy</a>
     <a href="./legal_notice.html" class="smallMenuLink">Legal Notice</a>
-    <a class="smallMenuLink" onclick="logout()">Log out</a>
+    <a href="#" class="smallMenuLink" data-action="logout" data-prevent-default="true">Log out</a>
   </div>
 </div>
 </div>

--- a/assets/templates/html_templates.js
+++ b/assets/templates/html_templates.js
@@ -136,7 +136,7 @@ function renderTasksHTML(task) {
   const safeTaskDescription = escapeHtml(task && task.description);
 
   return /*html*/ `
-      <a draggable="true" ondragstart="startDragging(${safeTaskId})" ondragend="stopDragging()" id="${safeTaskId}" class="card" href="#" onclick="openCard(${safeTaskId}); return false;">
+      <a draggable="true" id="${safeTaskId}" class="card" href="#" data-action="open-card" data-task-id="${safeTaskId}" data-prevent-default="true" data-dragstart-action="start-dragging" data-dragend-action="stop-dragging">
           <div class="cardTopContainer">
               <div id="cardType${safeTaskId}" class="cardType">${safeTaskType}</div>
               <div class="cardTitle">${safeTaskTitle}</div>
@@ -202,7 +202,7 @@ function renderLoginPageHTML() {
         </div>
         <div class="signUpField">
             <span>Not a join user yet?</span>
-            <button class="loginButtons signUpButton" onclick="renderSignUp()">Sign up</button>
+            <button type="button" class="loginButtons signUpButton" data-action="goto-signup">Sign up</button>
         </div>
     </header>
     <div class=" login-page">
@@ -212,7 +212,7 @@ function renderLoginPageHTML() {
                 <div class="horizontalH1Underline"></div>
             </div>
             <div class="formDiv">
-                <form onsubmit="loginUser(); return false;">
+                <form data-submit-action="login-user">
                     <div class=" innerLoginBox">
                         <div class="loginEmailBox">
                             <label class="sr-only" for="loginEmailInput">Email</label>
@@ -232,9 +232,9 @@ function renderLoginPageHTML() {
                             Remember me</label><br>
                     </div>
                     <div class="loginButtonsBox">
-                        <button class="loginButtons loginButtonUser" onclick="login()">Log in</button>
+                        <button type="submit" class="loginButtons loginButtonUser">Log in</button>
                         <!--TODO-->
-                        <button class="loginButtons loginButtonGuest">Guest log in</button>
+                        <button type="button" class="loginButtons loginButtonGuest" data-action="login-guest">Guest log in</button>
                     </div>
                 </form>
                 <!-- TODO darf nur angzeigt werden, wenn Nachricht wirklich da (z.B. you are signed up now!) -->
@@ -243,7 +243,7 @@ function renderLoginPageHTML() {
         </div>
         <div class="signUpField-mobile ">
             <span>Not a join user yet?</span>
-            <button class="loginButtons signUpButton signUpButton-mobile" onclick="renderSignUpPage()">Sign up</button>
+            <button type="button" class="loginButtons signUpButton signUpButton-mobile" data-action="goto-signup">Sign up</button>
         </div>
         <div class="loginFooter">
             <a class="privacyPolicy" href="./privacy_external.html" target="_blank" rel="noopener noreferrer"><span>Privacy policy</span></a>
@@ -269,7 +269,7 @@ function renderSignUpPageHTML() {
         </header>
         <div class="signUp-page">
             <div class="signUp-box">
-                <button type="button" class="arrowLeft" onclick="redirectToLogin()" aria-label="Back to login"><img src="./assets/img/icon-arrow_left.png" alt="arrow left"></button>
+                <button type="button" class="arrowLeft" data-action="redirect-to-login" aria-label="Back to login"><img src="./assets/img/icon-arrow_left.png" alt="arrow left"></button>
 
                 <div class="h1SignUpBox">
                     <h1 class="signUpH1">Sign up</h1>
@@ -277,7 +277,7 @@ function renderSignUpPageHTML() {
                 </div>
 
                 <div class="formDiv">
-                    <form onsubmit="addUser(); return false">
+                    <form data-submit-action="add-new-user">
                         <div class="innerSignUpBox">
                             <div class="signUpEmailBox">
                                 <label class="sr-only" for="signUpEmailInput">Email</label>
@@ -320,7 +320,7 @@ function renderBoardAddTaskHeaderHTML() {
   return /*html*/ `
     <div class="boardAddTaskHeader">
     <div class="boardAddTaskHeaderText">Add Task</div>
-    <button type="button" class="boardAddTaskCloseHoverContainer" onclick="hideAddTaskContainer()" aria-label="Close add task overlay"></button>
+    <button type="button" class="boardAddTaskCloseHoverContainer" data-action="hide-add-task-container" aria-label="Close add task overlay"></button>
  </div>`;
 }
 
@@ -359,7 +359,7 @@ function renderAddTaskMainContentHTML() {
                     <div class="addTaskDueDateInputContainer border-bottom pointer" id="addTaskDueDateInputContainer">
                         <label class="sr-only" for="addTaskDueDateInput">Due date</label>
                         <input class="addTaskDueDateInput" id="addTaskDueDateInput" type="date" aria-describedby="requiredDueDate" aria-invalid="false" value="">
-                        <button type="button" class="addTaskDueDateImage" onclick="addTaskDueDateOpenCalendear()" aria-label="Open due date picker"></button>
+                        <button type="button" class="addTaskDueDateImage" data-action="open-due-date-picker" aria-label="Open due date picker"></button>
                     </div>
                     <div class="addTaskRequired" id="requiredDueDate" role="alert" aria-live="polite"></div>
                 </div>
@@ -369,15 +369,15 @@ function renderAddTaskMainContentHTML() {
         <div class="addTaskPriority">
             <div class="addTaskTitles bold">Priority</div>
             <div class="addTaskPriorityButtonContainer">
-                <button type="button" id="addTaskPriorityButtonurgent" class="addTaskPriorityButton" onclick="setPriority('urgent')">
+                <button type="button" id="addTaskPriorityButtonurgent" class="addTaskPriorityButton" data-action="set-priority" data-priority="urgent">
                     <span class="priorityButtonText">Urgent</span>
                     <img src="./assets/img/icon-priority_urgent.png" alt="Priority urgent">
                 </button>
-                <button type="button" id="addTaskPriorityButtonmedium" class="addTaskPriorityButton" onclick="setPriority('medium')">
+                <button type="button" id="addTaskPriorityButtonmedium" class="addTaskPriorityButton" data-action="set-priority" data-priority="medium">
                     <span class="priorityButtonText">Medium</span>
                     <img src="./assets/img/icon-priority_medium.png" alt="Priority medium">
                 </button>
-                <button type="button" id="addTaskPriorityButtonlow" class="addTaskPriorityButton" onclick="setPriority('low')">
+                <button type="button" id="addTaskPriorityButtonlow" class="addTaskPriorityButton" data-action="set-priority" data-priority="low">
                     <span class="priorityButtonText">Low</span>
                     <img src="./assets/img/icon-priority_low.png" alt="Priority low">
                 </button>
@@ -386,7 +386,7 @@ function renderAddTaskMainContentHTML() {
         </div>
         <div class="addTaskContainer">
             <div class="addTaskTitle"><span class="bold">Assigned to</span> (optional)</div>
-            <button type="button" class="addTask-dropdown-contact pointer border-bottom" onclick="doNotClose(event); renderArrow('custom-arrow-assignedTo', 'dropdown-content-assignedTo')">
+            <button type="button" class="addTask-dropdown-contact pointer border-bottom" data-action="toggle-addtask-dropdown" data-arrow-container="custom-arrow-assignedTo" data-content-container="dropdown-content-assignedTo" data-stop-propagation="true">
                 <span class="addTask-custom-select">
                     <span id="dropdown-assignedTo-title">Select contacts to assign</span>
                     <span class="addTask-custom-arrow" id="custom-arrow-assignedTo">
@@ -394,13 +394,13 @@ function renderAddTaskMainContentHTML() {
                     </span>
                 </span>
             </button>
-                <div class="addTask-dropdown-content d-none" onclick="doNotClose(event)" id="dropdown-content-assignedTo">
+                <div class="addTask-dropdown-content d-none" data-stop-propagation="true" id="dropdown-content-assignedTo">
                 </div>
                 <div id="assignedContactsContainer" class="assignedContactsContainer cardAssignedToContainer d-none"></div>
         </div>
         <div class="addTaskContainer ">
             <div class="addTaskTitle bold">Category </div>
-            <button type="button" class="addTask-dropdown-category pointer border-bottom" onclick="doNotClose(event); renderArrow('custom-arrow-category', 'dropdown-content-category')">
+            <button type="button" class="addTask-dropdown-category pointer border-bottom" data-action="toggle-addtask-dropdown" data-arrow-container="custom-arrow-category" data-content-container="dropdown-content-category" data-stop-propagation="true">
                 <span class="addTask-custom-select">
                     <span id="dropdown-category-title">Select task category</span>
                         <span class="addTask-custom-arrow" id="custom-arrow-category">
@@ -408,15 +408,15 @@ function renderAddTaskMainContentHTML() {
                     </span>
                 </span>
             </button>
-            <div class="addTask-dropdown-content d-none no-scroll" onclick="doNotClose(event)" id="dropdown-content-category">
-                <button type="button" class="dropdownOption" onclick="chooseCategory('Technical Task')">Technical Task</button>
-                <button type="button" class="dropdownOption" onclick="chooseCategory('User Story')">User Story</button>
+            <div class="addTask-dropdown-content d-none no-scroll" data-stop-propagation="true" id="dropdown-content-category">
+                <button type="button" class="dropdownOption" data-action="choose-category" data-category="Technical Task">Technical Task</button>
+                <button type="button" class="dropdownOption" data-action="choose-category" data-category="User Story">User Story</button>
             </div>
         </div>
         <div class="addTaskContainer">
             <div class="addTaskTitles"><span class="bold">Subtasks</span> (optional)
             </div>
-            <button type="button" id="subtaskBottom" class="subtaskBottom border-bottom" onclick="renderSubtaskInputField()">
+            <button type="button" id="subtaskBottom" class="subtaskBottom border-bottom" data-action="render-subtask-input-field">
                 <span id="subtaskInputFieldDiv">Add new subtask</span>
                 <span id="subtaskImgAddPlus" class="subtaskImgDiv pointer"></span>
             </button>
@@ -427,7 +427,7 @@ function renderAddTaskMainContentHTML() {
         <div class="addTaskContainer">
             <div class="addTaskTitles"><span class="bold">Attachments</span> (optional)</div>
             <div id="addImageBottom" class="addImageBottom border-bottom">
-            <button type="button" class="uploadImageButton" onclick="openFilepicker()" aria-label="Upload attachment">
+            <button type="button" class="uploadImageButton" data-action="open-filepicker" aria-label="Upload attachment">
             <img src="./assets/img/upload.png" alt="upload">
             </button>
             <input type="file" id="filepicker" style="display: none" accept="image/*" multiple dropzone="copy">
@@ -443,7 +443,7 @@ function renderAddTaskMainContentHTML() {
 function renderAddTaskFooterHTML() {
   return /*html*/ `
             <div class="addTaskBtnContainer">
-                <button type="button" class="clearBtn addTaskBtn" onclick="clearFormular()">
+                <button type="button" class="clearBtn addTaskBtn" data-action="clear-formular">
                     <span class="addTaskBtnText">Clear</span>
                     <span class="clearBtnImg"></span>
                 </button>
@@ -470,7 +470,7 @@ function renderOpenCardHTML(task) {
 
   return /*html*/ `
       <div class="boardAddTaskCloseHoverOuterContainer">
-          <button type="button" class="boardAddTaskCloseHoverContainer" onclick="closeCard()" aria-label="Close task details"></button>
+          <button type="button" class="boardAddTaskCloseHoverContainer" data-action="close-card" aria-label="Close task details"></button>
       </div>
       <div class="openCardInnerContainer">
           <div id="openCardType${safeTaskId}" class="cardType">${safeTaskType}</div>
@@ -493,12 +493,12 @@ function renderOpenCardHTML(task) {
           <div id="openCardSubtasksContainer"></div>
           <div id="openCardImagesContainer" class="openCardImagesContainer"></div>
           <div class="openCardDeleteEditContainer">
-              <button type="button" class="openCardDeleteContainer" onclick='openCardDelete(${safeTaskId})'>
+              <button type="button" class="openCardDeleteContainer" data-action="open-card-delete" data-task-id="${safeTaskId}">
                   <span class="openCardImgDiv pointer" id="openCardImgDelete"></span>
                   <span>Delete</span>
               </button>
               <div class="vLine"></div>
-              <button type="button" class="openCardEditContainer" onclick='openCardEdit(${safeTaskId})'>
+              <button type="button" class="openCardEditContainer" data-action="open-card-edit" data-task-id="${safeTaskId}">
                   <span class="openCardImgDiv pointer" id="openCardImgEdit"></span>
                   <span>Edit</span>
               </button>
@@ -520,8 +520,8 @@ function editSubtaskHTML(subtask) {
         <label class="sr-only" for="subtaskEditInputField">Edit subtask</label>
         <input type="text" id="subtaskEditInputField" value="${safeSubtaskText}">
         <div class="subtaskCheckboxes">
-        <button type="button" class="subtaskImgDiv pointer" id="subtaskImgDelete" onclick="deleteSubtask(${safeSubtaskId})" aria-label="Delete subtask"></button><div class="vLine"></div>
-            <button type="button" class="subtaskImgDiv pointer" id="subtaskImgAddCheck" onclick="saveEditSubtask(${safeSubtaskId})" aria-label="Save subtask"></button>
+        <button type="button" class="subtaskImgDiv pointer" id="subtaskImgDelete" data-action="delete-subtask" data-subtask-id="${safeSubtaskId}" aria-label="Delete subtask"></button><div class="vLine"></div>
+            <button type="button" class="subtaskImgDiv pointer" id="subtaskImgAddCheck" data-action="save-edit-subtask" data-subtask-id="${safeSubtaskId}" aria-label="Save subtask"></button>
         </div>`;
 }
 
@@ -538,11 +538,11 @@ function editSubtaskHTML(subtask) {
 function renderSubtaskInputFieldHTML() {
   return /*html*/ `
      <label class="sr-only" for="subtaskInputField">Subtask</label>
-     <input type="text" id="subtaskInputField" placeholder="Add new subtask" onclick="doNotClose(event)">
+     <input type="text" id="subtaskInputField" placeholder="Add new subtask" data-stop-propagation="true">
      <div class="subtaskAddOrCancel">
-         <button type="button" id="subtaskImgAddCheck" class="subtaskImgDiv pointer" onclick="subtaskAddOrCancel('add'); doNotClose(event)" aria-label="Add subtask"></button>
+         <button type="button" id="subtaskImgAddCheck" class="subtaskImgDiv pointer" data-action="subtask-add-or-cancel" data-option="add" data-stop-propagation="true" aria-label="Add subtask"></button>
          <div class="vLine"></div>
-         <button type="button" id="subtaskImgAddCancel" class="subtaskImgDiv pointer" onclick="subtaskAddOrCancel('cancel'); doNotClose(event)" aria-label="Cancel subtask input"></button>
+         <button type="button" id="subtaskImgAddCancel" class="subtaskImgDiv pointer" data-action="subtask-add-or-cancel" data-option="cancel" data-stop-propagation="true" aria-label="Cancel subtask input"></button>
      </div>`;
 }
 
@@ -562,12 +562,12 @@ function renderSubtaskHTML(outputContainer, subtask) {
   const safeSubtaskText = escapeHtml(subtask && subtask.subtaskText);
 
   outputContainer.innerHTML += /*html*/ `
-        <div class="subTaskOutputDiv" id="subtask${safeSubtaskId}" ondblclick="editSubtask(${safeSubtaskId})">
+        <div class="subTaskOutputDiv" id="subtask${safeSubtaskId}" data-dblclick-action="edit-subtask" data-subtask-id="${safeSubtaskId}">
         <div class="subtaskText">${safeSubtaskText}</div>
             <div class="subtaskCheckboxes">
-                <button type="button" class="subtaskImgDiv pointer" id="subtaskImgEdit" onclick="editSubtask(${safeSubtaskId})" aria-label="Edit subtask"></button>
+                <button type="button" class="subtaskImgDiv pointer" id="subtaskImgEdit" data-action="edit-subtask" data-subtask-id="${safeSubtaskId}" aria-label="Edit subtask"></button>
                 <div class="vLine"></div>
-                <button type="button" class="subtaskImgDiv pointer" id="subtaskImgDelete" onclick="deleteSubtask(${safeSubtaskId})" aria-label="Delete subtask"></button>
+                <button type="button" class="subtaskImgDiv pointer" id="subtaskImgDelete" data-action="delete-subtask" data-subtask-id="${safeSubtaskId}" aria-label="Delete subtask"></button>
             </div>
         </div>`;
 }

--- a/board.html
+++ b/board.html
@@ -34,7 +34,7 @@
     <title>Join - AddTask</title>
 </head>
 
-<body onload="boardInit()">
+<body data-init="boardInit">
     <div id="bodyContent" class="bodyContent">
         <header w3-include-html="./assets/templates/header.html" id="header" class="header">
         </header>
@@ -45,12 +45,12 @@
                 <div class="board-Container">
                     <div class="boardTopContainer">
                         <div class="searchTaskContainer">
-                            <div class="searchTaskInner"><input id="findTask" placeholder="Find Task" type="text" onkeyup="searchTask()">
-                                <button type="button" class="searchImg" onclick="searchTask()" aria-label="Search tasks"></button>
+                            <div class="searchTaskInner"><input id="findTask" placeholder="Find Task" type="text" data-keyup-action="search-task">
+                                <button type="button" class="searchImg" data-action="search-task" aria-label="Search tasks"></button>
                             </div>
                         </div>
                         <div class="boardAddTaskButtonContainer">
-                            <button type="button" class="createBtn addTaskBtn addTaskBtnBoard btnBoard" onclick="doNotClose(event); showAddTaskContainer()">
+                            <button type="button" class="createBtn addTaskBtn addTaskBtnBoard btnBoard" data-action="open-add-task-container" data-category="category-0" data-stop-propagation="true">
                                 <span class="addTaskBtnText">Add Task</span>
                                 <span class="addTaskBtnImg "></span>
                             </button>
@@ -58,35 +58,35 @@
 
                     </div>
                     <div class="category-container">
-                        <div class="category" ondrop="moveTo('category-0')"
-                            ondragover="allowDrop(event)">
+                        <div class="category" data-drop-action="move-to" data-category="category-0"
+                            data-dragover-action="allow-drop">
                             <div class="categoryTitle">
                                 <h2>To Do</h2>
-                                <button type="button" class="addTaskButton" onclick="showAddTaskContainer('category-0')" aria-label="Add task to To Do"></button>
+                                <button type="button" class="addTaskButton" data-action="open-add-task-container" data-category="category-0" aria-label="Add task to To Do"></button>
                             </div>
                             <div id="category-0" class="categoryTasks">
                             </div>
                         </div>
-                        <div class="category" ondrop="moveTo('category-1')" ondragover="allowDrop(event)">
+                        <div class="category" data-drop-action="move-to" data-category="category-1" data-dragover-action="allow-drop">
                             <div class=" categoryTitle">
                             <h2>In progress</h2>
-                            <button type="button" class="addTaskButton" onclick="showAddTaskContainer('category-1')" aria-label="Add task to In progress"></button>
+                            <button type="button" class="addTaskButton" data-action="open-add-task-container" data-category="category-1" aria-label="Add task to In progress"></button>
                         </div>
                         <div id="category-1" class="categoryTasks">
                         </div>
                     </div>
-                    <div class="category" ondrop="moveTo('category-2')" ondragover="allowDrop(event)">
+                    <div class="category" data-drop-action="move-to" data-category="category-2" data-dragover-action="allow-drop">
                             <div class=" categoryTitle">
                         <h2>Await feedback</h2>
-                        <button type="button" class="addTaskButton" onclick="showAddTaskContainer('category-2')" aria-label="Add task to Await feedback"></button>
+                        <button type="button" class="addTaskButton" data-action="open-add-task-container" data-category="category-2" aria-label="Add task to Await feedback"></button>
                     </div>
                     <div id="category-2" class="categoryTasks">
                     </div>
                 </div>
-                <div class="category" ondrop="moveTo('category-3')" ondragover="allowDrop(event)">
+                <div class="category" data-drop-action="move-to" data-category="category-3" data-dragover-action="allow-drop">
                     <div class="categoryTitle">
                         <h2>Done</h2>
-                        <button type="button" class="addTaskButton" onclick="showAddTaskContainer('category-3')" aria-label="Add task to Done"></button>
+                        <button type="button" class="addTaskButton" data-action="open-add-task-container" data-category="category-3" aria-label="Add task to Done"></button>
                     </div>
                     <div id="category-3" class="categoryTasks">
                     </div>

--- a/contacts.html
+++ b/contacts.html
@@ -28,7 +28,7 @@
     <title>Join - Contacts</title>
 </head>
 
-<body onload="contactsInit()">
+<body data-init="contactsInit">
     <div id="bodyContent" class="bodyContent">
         <header w3-include-html="./assets/templates/header.html" id="header" class="header">
         </header>

--- a/help.html
+++ b/help.html
@@ -20,7 +20,7 @@
     <title>Join - Help</title>
 </head>
 
-<body onload="helpInit()">
+<body data-init="helpInit">
     <div id="bodyContent" class="bodyContent">
         <header w3-include-html="./assets/templates/header.html" id="header" class="header">
         </header>
@@ -31,7 +31,7 @@
                 <div class="help-page">
                     <div class="help-page-header">
                         <h1>Help</h1>
-                        <img src="./assets/img/icon-arrow_left.png" onclick="goBack()">
+                        <img src="./assets/img/icon-arrow_left.png" data-action="go-back">
                     </div>
 
                     <div>

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
     <title>Join - Login</title>
 </head>
 
-<body onload="loginInit()">
+<body data-init="loginInit">
     <div id="bodyContent" class="bodyContent">
         <main id="main" class="main hide-scroll signup-active">
             <div id="loginMainContainer" class="loginMainContainer">
@@ -34,7 +34,7 @@
                     </div>
                     <div class="signUpField">
                         <span>Not a join user yet?</span>
-                        <button type="button" class="loginButtons signUpButton" onclick="gotoSignUp()">Sign up</button>
+                        <button type="button" class="loginButtons signUpButton" data-action="goto-signup">Sign up</button>
                     </div>
                 </header>
                 <div class=" login-page">
@@ -43,7 +43,7 @@
                             <h1 class="loginH1">Log in</h1>
                             <div class="horizontalH1Underline"></div>
                         </div>
-                        <form id="loginForm" onsubmit="loginUser(); return false;">
+                        <form id="loginForm" data-submit-action="login-user">
                             <div class="innerLoginBox">
                                 <div class="loginInputField">
                                     <label class="sr-only" for="loginEmailInput">Email</label>
@@ -57,7 +57,7 @@
                                     <div class="mailIcon"><img src="./assets/img/icon-lock.png" alt="lock">
                                     </div>
                                 </div>
-                                <button type="button" id="loginCheckbox" class="checkboxBox" onclick="toggleRememberMeCheckbox()"
+                                <button type="button" id="loginCheckbox" class="checkboxBox" data-action="toggle-remember-me"
                                     aria-label="Toggle remember me">
                                     <img id="loginCheckboxImg" src="./assets/img/icon-check_button_unchecked.png"
                                         alt="checkbox image">
@@ -67,12 +67,12 @@
                         </form>
                         <div class="loginButtonsBox">
                             <button class="loginButtons loginButtonUser" form="loginForm">Login</button>
-                            <button type="button" class="loginButtons loginButtonGuest" onclick="loginAsGuest()">Guest Login</button>
+                            <button type="button" class="loginButtons loginButtonGuest" data-action="login-guest">Guest Login</button>
                         </div>
                     </div>
                     <div class="signUpField-mobile d-none">
                         <span>Not a join user?</span>
-                        <button type="button" class="loginButtons signUpButton signUpButton-mobile" onclick="gotoSignUp()">Sign
+                        <button type="button" class="loginButtons signUpButton signUpButton-mobile" data-action="goto-signup">Sign
                             up</button>
                     </div>
                 </div>

--- a/js/addTask.js
+++ b/js/addTask.js
@@ -101,7 +101,7 @@ function subtaskAddOrCancel(option) {
         }
     }
     subtaskBottom.innerHTML = renderSubtaskDefaultHTML();
-    subtaskBottom.setAttribute('onclick', 'renderSubtaskInputField()');
+    subtaskBottom.dataset.action = 'render-subtask-input-field';
 }
 
 
@@ -345,15 +345,13 @@ function focusFirstDropdownControl(dropdownContainer){
 
 
 /**
- * Sets the onclick event handler for the container element based on the open dropdowns.
- * If there are open dropdowns, the onclick event handler is set to render the arrow based on the dropdown id.
- * If there are no open dropdowns, the onclick event handler is removed from the container element.
+ * Sets delegated close behavior for outside container based on the open dropdowns.
  *
  * @return {void}
  */
 function setCloseDropdownContainer(){
     let openendDropdowns = document.getElementsByClassName('dropdown-opened');
-    let container = getContainerToSetOnclick();
+    let container = getContainerToSetDropdownCloseAction();
     if (!container) {
         return;
     }
@@ -361,25 +359,31 @@ function setCloseDropdownContainer(){
     if (!openendDropdowns.length == 0){
         for (let i=0; i<openendDropdowns.length; i++){
             if (openendDropdowns[i].id == 'dropdown-content-assignedTo'){
-                container.setAttribute('onclick', 'renderArrow("custom-arrow-assignedTo", "dropdown-content-assignedTo")');
+                container.dataset.action = 'toggle-addtask-dropdown';
+                container.dataset.arrowContainer = 'custom-arrow-assignedTo';
+                container.dataset.contentContainer = 'dropdown-content-assignedTo';
             }
             if (openendDropdowns[i].id == 'dropdown-content-category'){
-                container.setAttribute('onclick', 'renderArrow("custom-arrow-category", "dropdown-content-category")');
+                container.dataset.action = 'toggle-addtask-dropdown';
+                container.dataset.arrowContainer = 'custom-arrow-category';
+                container.dataset.contentContainer = 'dropdown-content-category';
             }
         }
     }
     else{
-        container.removeAttribute('onclick')
+        delete container.dataset.action;
+        delete container.dataset.arrowContainer;
+        delete container.dataset.contentContainer;
     }
 }
 
 
 /**
- * Returns the container element to set the onclick attribute on based on the current page location.
+ * Returns the container element to set delegated dropdown-close action on.
  *
- * @return {HTMLElement} The container element to set the onclick attribute on. Returns the 'bodyContent' element if the current page location includes 'addTask', the 'openCardContainer' element if it exists, or the 'addTaskHoverContainer' element if it exists.
+ * @return {HTMLElement} Container used for outside-click dropdown close behavior.
  */
-function getContainerToSetOnclick(){
+function getContainerToSetDropdownCloseAction(){
     if (window.location.href.includes('addTask')){
         return document.getElementById('bodyContent')
     } else {
@@ -402,7 +406,7 @@ function renderContactsToDropdown(){
         const safeContactId = toSafeInteger(contact && contact.id);
         const safeContactName = escapeHtml(contact && contact.name);
 
-        content.innerHTML += /*html*/`<button type="button" class="dropdownOption" id="assignedToContact${safeContactId}" marked=false onclick="assignContactToTask(${safeContactId})">
+        content.innerHTML += /*html*/`<button type="button" class="dropdownOption" id="assignedToContact${safeContactId}" marked=false data-action="assign-contact-to-task" data-contact-id="${safeContactId}">
             <span class="dropdownContactBadgeAndName">${renderAssignedToButtonsHTML(contact)} ${safeContactName}</span> <img src="./assets/img/icon-check_button_unchecked.png" alt="">
             </button>`
     })
@@ -552,7 +556,7 @@ function getStateOfRequriredField(requiredInputField){
  */
 function setCreateBtnState() {
 	if (requiredInputFields.every((r) => r.state == true)) {
-        activateButton('createBtn', 'createTask()');
+        activateButton('createBtn', 'create-task');
 	} else {
         deactivateButton('createBtn');
 	}
@@ -560,12 +564,12 @@ function setCreateBtnState() {
 
 
 /**
- * Activates a button by removing the "disabled" class and setting the "onclick" attribute.
+ * Activates a button by removing the disabled state and wiring its delegated click action.
  *
  * @param {string} id - The ID of the button element.
- * @param {string} onClickFunctionName - The name of the function to be called when the button is clicked.
+ * @param {string} actionName - The data-action value handled by delegated events.
  */
-function activateButton(id, onClickFunctionName){
+function activateButton(id, actionName){
     if(document.getElementById(id)){
         let btn = document.getElementById(id);
         btn.classList.remove("disabled");
@@ -573,13 +577,15 @@ function activateButton(id, onClickFunctionName){
             btn.disabled = false;
             btn.setAttribute("aria-disabled", "false");
         }
-        btn.setAttribute("onclick", onClickFunctionName);
+        if (actionName) {
+            btn.dataset.action = actionName;
+        }
     }
 }
 
 
 /**
- * Deactivates a button by adding the "disabled" class and removing the "onclick" attribute.
+ * Deactivates a button by adding the disabled state and removing delegated action wiring.
  *
  * @param {string} id - The ID of the button element.
  */
@@ -591,6 +597,6 @@ function deactivateButton(id){
             btn.disabled = true;
             btn.setAttribute("aria-disabled", "true");
         }
-        btn.removeAttribute("onclick");
+        delete btn.dataset.action;
     }
 }

--- a/js/board.js
+++ b/js/board.js
@@ -437,7 +437,7 @@ function finalizeEdit() {
 function createEditHeader(){
     return /*html*/`
 <div class="boardEditTaskHeader">
-    <button type="button" class="boardAddTaskCloseHoverContainer" onclick="closeCard()" aria-label="Close edit card"></button>
+    <button type="button" class="boardAddTaskCloseHoverContainer" data-action="close-card" aria-label="Close edit card"></button>
  </div>
     `
 }
@@ -454,7 +454,7 @@ function createEditFooter(task){
 
     return /*html*/`
     <div class="addTaskBodyRight">
-        <button type="button" class="createBtn addTaskBtn" onclick="saveEditedTask(${safeTaskId}); doNotClose(event)">
+        <button type="button" class="createBtn addTaskBtn" data-action="save-edited-task" data-task-id="${safeTaskId}" data-stop-propagation="true">
             <span class="addTaskBtnText">Ok</span>
             <span class="createBtnImg"></span>
         </button>

--- a/js/board_popups.js
+++ b/js/board_popups.js
@@ -10,7 +10,7 @@ function openCard(taskId){
         setAttributes(newDiv, {
             'id': 'openCardContainer',
             'class': 'openCardContainer',
-            'onclick': 'doNotClose(event)'
+            'data-stop-propagation': 'true'
         });
         document.body.appendChild(newDiv);
     }
@@ -30,7 +30,7 @@ function openCard(taskId){
     if(task.images && task.images.length > 0) {
         renderOpenCardImages(task);
     }
-    toggleBoardOverlay('closeCard()');
+    toggleBoardOverlay('close-card');
     activateFocusLayer(openCardContainer, {
         opener,
         initialFocus: '.boardAddTaskCloseHoverContainer',
@@ -95,7 +95,7 @@ function renderContactsToOpenCard(task) {
  */
 function renderBoardAddTaskOverlay(){
     let newDiv = document.createElement('div');
-    setAttributes(newDiv, {'id': 'addTaskHoverContainer', 'class': 'addTaskHoverContainer', 'onclick': 'doNotClose(event)'});
+    setAttributes(newDiv, {'id': 'addTaskHoverContainer', 'class': 'addTaskHoverContainer', 'data-stop-propagation': 'true'});
     document.body.appendChild(newDiv);
 
     let container = document.getElementById('addTaskHoverContainer');
@@ -133,7 +133,7 @@ function showAddTaskContainer(category='category-0') {
     }
     let container = document.getElementById('addTaskHoverContainer');
     container.classList.add('showBoard');
-    toggleBoardOverlay("hideAddTaskContainer()");
+    toggleBoardOverlay("hide-add-task-container");
     activateFocusLayer(container, {
         opener,
         initialFocus: '.boardAddTaskCloseHoverContainer, #addTaskEnterTitleInput',
@@ -173,16 +173,16 @@ function hideAddTaskContainer(){
 /**
  * Toggles the board overlay visibility based on the provided function to call.
  *
- * @param {string} functionToCall - The function to be called on overlay click.
+ * @param {string} actionName - Delegated action to trigger on overlay click.
  */
-function toggleBoardOverlay(functionToCall){
+function toggleBoardOverlay(actionName){
     let overlay = document.getElementById('boardOverlay')
     if (overlay.classList.contains('d-none')){
         overlay.classList.remove('d-none')
-        overlay.setAttribute('onclick', functionToCall);
-    } else if (functionToCall == 'disable') {
+        overlay.dataset.action = actionName;
+    } else if (actionName == 'disable') {
         overlay.classList.add('d-none')
-        overlay.removeAttribute('onclick');
+        delete overlay.dataset.action;
     }
 }
 

--- a/js/contact_popups.js
+++ b/js/contact_popups.js
@@ -216,7 +216,7 @@ function addContactCard() {
     renderAddContacts();
   }
   document.getElementById("addContact").innerHTML = renderAddContactsHTML();
-  addOverlay("closeOverlay('addContact')");
+  addOverlay("addContact");
   activateFocusLayer("addContact", {
     opener: contactOverlayOpener,
     initialFocus: "#contactName",
@@ -227,17 +227,18 @@ function addContactCard() {
 
 /**
  * Creates an overlay element and appends it to the document body. The overlay element
- * has a class of "overlay" and an onclick attribute set to the provided functionToAdd.
+ * has a class of "overlay" and delegated close action data attributes.
  * Additionally, the overflow style of the document body is set to "hidden" to prevent
  * scrolling while the overlay is active.
  *
- * @param {string} functionToAdd - The function to be called when the overlay is clicked.
+ * @param {string} overlayId - The overlay container id to close on overlay click.
  * @return {void} This function does not return a value.
  */
-function addOverlay(functionToAdd) {
+function addOverlay(overlayId) {
   const overlay = document.createElement("div");
   overlay.classList.add("overlay");
-  overlay.setAttribute("onclick", functionToAdd);
+  overlay.dataset.action = "close-overlay";
+  overlay.dataset.overlayId = overlayId;
 
   document.body.appendChild(overlay);
   document.body.style.overflow = "hidden";
@@ -285,7 +286,7 @@ function renderAddContacts() {
   newDiv.id = "addContact";
   setAttributes(newDiv, {
     class: "add-contact",
-    onclick: "doNotClose(event)",
+    "data-stop-propagation": "true",
   });
   document.getElementById("addContactContainer").appendChild(newDiv);
 }
@@ -426,7 +427,7 @@ function editContactCard(contact) {
     contact.name,
     contact.contactColor
   );
-  addOverlay("closeOverlay('editContact')");
+  addOverlay("editContact");
   activateFocusLayer("editContact", {
     opener: contactOverlayOpener,
     initialFocus: "#contactName",

--- a/js/contacts_render.js
+++ b/js/contacts_render.js
@@ -6,7 +6,7 @@
  */
 function generateContactsContainerHTML() {
     return /*html*/ ` 
-    <div id="contactMainEdit" class="contact-main-edit" onclick="doNotClose(event)">
+    <div id="contactMainEdit" class="contact-main-edit" data-stop-propagation="true">
 
   </div>
   <div class="contact-list-container">
@@ -14,12 +14,12 @@ function generateContactsContainerHTML() {
       <div id="addContactContainer" class="hidden">
       </div>
   </div>
-  <button type="button" class="add-contact-button" onclick="addContactCard()" aria-label="Add new contact">
+  <button type="button" class="add-contact-button" data-action="add-contact-card" aria-label="Add new contact">
     <img src="./assets/img/Secondary mobile contact V1.png" alt="">
   </button>
   <div class="contacts-container-outer">
     <div class="contacts-container" id="contacts-container"> 
-            <div id="button-add-contact-card" class="button-add-contact" onclick="addContactCard(); doNotClose(event)">
+            <div id="button-add-contact-card" class="button-add-contact" data-action="add-contact-card" data-stop-propagation="true">
                 <div class="add-new-contact">Add new contact</div>
                 <img src="./assets/img/icon-person_add.png" alt="icon-person_add.png">
             </div>
@@ -27,7 +27,7 @@ function generateContactsContainerHTML() {
         </div>
     </div>
   </div>
-  <section class="right-side d-none" id="rightSide" onclick="closeEditDelete()">
+  <section class="right-side d-none" id="rightSide" data-action="close-edit-delete">
   
   </section>
       `;
@@ -42,7 +42,7 @@ function renderAddContactsHTML() {
     return /*html*/ `
           <div class="add-contact-header">
               <div class="add-contact-header-close">
-                  <button type="button" class="icon-action-button" onclick="closeOverlay('addContact')" aria-label="Close add contact form">
+                  <button type="button" class="icon-action-button" data-action="close-overlay" data-overlay-id="addContact" aria-label="Close add contact form">
                       <img src="./assets/img/icon-close_white.png" alt="">
                   </button>
               </div>
@@ -58,7 +58,7 @@ function renderAddContactsHTML() {
                       <img src="./assets/img/add.contact-badge.png" alt="">
                   </div>
               </div>
-              <form onsubmit="saveContact(); return false" class="add-contact-input-group">
+              <form data-submit-action="save-contact" class="add-contact-input-group">
                   <div class="input-frame">
                       <label class="sr-only" for="contactName">Name</label>
                       <input id="contactName" type="text" placeholder="Name" autocomplete="name" autofocus required>
@@ -75,8 +75,8 @@ function renderAddContactsHTML() {
                       <img src="./assets/img/icon-call.png" alt="">
                   </div>
                   <div id="addContactButton" class="addContactButton">
-                      <button type="button" class="cancelButton" onclick="closeOverlay('addContact')" onmouseover="changeCancelIcon()"
-                          onmouseout="restoreCancelIcon()">Cancel
+                      <button type="button" class="cancelButton" data-action="close-overlay" data-overlay-id="addContact" data-hover-action="change-cancel-icon"
+                          data-leave-action="restore-cancel-icon">Cancel
                           <img id="cancelIcon" src="./assets/img/icon-cancel.png" alt="">
                       </button>
                       <button type="submit" id="createBtn" class="createButton">Create contact
@@ -102,7 +102,7 @@ function renderEditContactHTML(id, name, contactColor) {
     return /*html*/ `
           <div class="edit-contact-header">
               <div class="edit-contact-header-close">
-                  <button type="button" class="icon-action-button" onclick="closeOverlay('editContact')" aria-label="Close edit contact form">
+                  <button type="button" class="icon-action-button" data-action="close-overlay" data-overlay-id="editContact" aria-label="Close edit contact form">
                       <img src="./assets/img/icon-close_white.png" alt="">
                   </button>
               </div>
@@ -121,7 +121,7 @@ function renderEditContactHTML(id, name, contactColor) {
             </div>
                   </div>
               </div>
-              <form action="" onsubmit="saveEditedContact(${safeContactId}); return false" class="add-contact-input-group">
+              <form action="" data-submit-action="save-edited-contact" data-contact-id="${safeContactId}" class="add-contact-input-group">
                   <div class="input-frame">
                       <label class="sr-only" for="contactName">Name</label>
                       <input id="contactName" type="text" placeholder="Name" autocomplete="name" autofocus required>
@@ -138,8 +138,8 @@ function renderEditContactHTML(id, name, contactColor) {
                       <img src="./assets/img/icon-call.png" alt="">
                   </div>
                   <div id="addContactButton" class="addContactButton">
-                      <button type="button" class="cancelButton" onclick="closeOverlay('editContact')" onmouseover="changeCancelIcon()"
-                          onmouseout="restoreCancelIcon()">Cancel
+                      <button type="button" class="cancelButton" data-action="close-overlay" data-overlay-id="editContact" data-hover-action="change-cancel-icon"
+                          data-leave-action="restore-cancel-icon">Cancel
                           <img id="cancelIcon" src="./assets/img/icon-cancel.png" alt="">
                       </button>
                       <button class="createButton" type="submit">Save
@@ -177,7 +177,7 @@ function generateContactCardHTML(
     const safeShorterMail = escapeHtml(shorterMail);
 
     return /*html*/ `
-      <div class="contact-card" id="contact-card-${safeContactId}" onclick="openContactDetails(${safeContactId})">
+      <div class="contact-card" id="contact-card-${safeContactId}" data-action="open-contact-details" data-contact-id="${safeContactId}">
         <div class="profile-badge-group" style="background-color: ${safeProfileColor}">${safeInitials}</div>
         <div>
           <span class="contact-card-name">${safeFormattedName}</span><br>
@@ -210,7 +210,7 @@ function generateContactDetailsHTML(name, email, phone, id, color) {
       <div class="contact-Details">
         <div class="contact-details-header-and-button">
           <div class="contact-details-header-responsive">Contact Information</div>
-          <button type="button" class="contact-details-back-button" onclick="openContactDetails(${safeContactId})" aria-label="Back to contact list">
+          <button type="button" class="contact-details-back-button" data-action="open-contact-details" data-contact-id="${safeContactId}" aria-label="Back to contact list">
             <img src="./assets/img/icon-arrow_left.png">
           </button>
         </div>
@@ -223,10 +223,10 @@ function generateContactDetailsHTML(name, email, phone, id, color) {
           <div class="contact-details-name-group">
             <div class="contact-details-name">${safeContactName}</div>
             <div class="contact-details-icons">
-              <div class="icon-edit" onclick="editContact(${safeContactId})">
+              <div class="icon-edit" data-action="edit-contact" data-contact-id="${safeContactId}">
                 <img src="./assets/img/icon-edit.png" alt="">Edit
               </div>
-              <div class="icon-delete" onclick="removeContact(${safeContactId})">
+              <div class="icon-delete" data-action="remove-contact" data-contact-id="${safeContactId}">
                 <img src="./assets/img/icon-delete.png" alt="">Delete
               </div>
             </div>
@@ -244,15 +244,15 @@ function generateContactDetailsHTML(name, email, phone, id, color) {
             <div class="contact-phone-container-phone">${safePhone}</div>
           </div>
         </div>
-        <button type="button" class="openEditDeleteResponsive" id="openEditDeleteResponsive" onclick="openEditDelete(); doNotClose(event)" aria-label="Open contact actions menu">
+        <button type="button" class="openEditDeleteResponsive" id="openEditDeleteResponsive" data-action="open-edit-delete" data-stop-propagation="true" aria-label="Open contact actions menu">
           <img src="./assets/img/Menu Contact options.png" alt="">
         </button>
-        <div class="editDelete d-none" id="editDelete" onclick="doNotClose(event)">
-          <div class="editDiv" onclick="editContact(${safeContactId})">
+        <div class="editDelete d-none" id="editDelete" data-stop-propagation="true">
+          <div class="editDiv" data-action="edit-contact" data-contact-id="${safeContactId}">
             <img src="./assets/img/icon-edit.png" alt="">
             <span>Edit</span>
             </div>
-          <div class="deleteDiv" onclick="removeContact(${safeContactId})">
+          <div class="deleteDiv" data-action="remove-contact" data-contact-id="${safeContactId}">
               <img src="./assets/img/icon-delete.png" alt="">
               <span>Delete</span>
             </div>

--- a/legal_notice.html
+++ b/legal_notice.html
@@ -24,10 +24,10 @@
     <title>Join - Legal Notice</title>
 </head>
 
-<body onload="privacyInit()">
+<body data-init="privacyInit">
     <div id="bodyContent" class="bodyContent">
         <div class="header-content">
-            <img class="header-logo" src="./assets/img/logo-small_white.png" alt="join-logo" onclick="switchPage('summary.html')"/>
+            <img class="header-logo" src="./assets/img/logo-small_white.png" alt="join-logo" data-action="switch-page" data-url="summary.html"/>
             <div class="header-inner-right">
                 <span class="header-kanban-writing">Kanban Project Management Tool</span>
             </div>
@@ -38,7 +38,7 @@
                 <div class="legal_notice-wrapper">
                     <div class="h1LegalNoticeBox">
                         <h1>Legal Notice</h1>
-                        <img src="./assets/img/icon-arrow_left.png" alt="going-back arrow" onclick="goBack()">
+                        <img src="./assets/img/icon-arrow_left.png" alt="going-back arrow" data-action="go-back">
                     </div>
                     <div>
                         <div class="imprint1">

--- a/legal_notice_external.html
+++ b/legal_notice_external.html
@@ -26,10 +26,10 @@
     <title>Join - Legal Notice External</title>
 </head>
 
-<body onload="privacyInit()">
+<body data-init="privacyInit">
     <div id="bodyContent" class="bodyContent">
         <div class="header-content">
-            <img class="header-logo" src="./assets/img/logo-small_white.png" alt="join-logo" onclick="switchPage('index.html')"/>
+            <img class="header-logo" src="./assets/img/logo-small_white.png" alt="join-logo" data-action="switch-page" data-url="index.html"/>
             <div class="header-inner-right">
                 <span class="header-kanban-writing">Kanban Project Management Tool</span>
             </div>
@@ -41,7 +41,7 @@
                 <div class="legal_notice-wrapper">
                     <div class="h1LegalNoticeBox">
                         <h1>Legal Notice</h1>
-                        <img src="./assets/img/icon-arrow_left.png" alt="going-back arrow" onclick="goBack()">
+                        <img src="./assets/img/icon-arrow_left.png" alt="going-back arrow" data-action="go-back">
                     </div>
                     <div>
                         <div class="imprint1">

--- a/privacy.html
+++ b/privacy.html
@@ -21,10 +21,10 @@
     <title>Join - Privacy Policy</title>
 </head>
 
-<body onload="privacyInit()">
+<body data-init="privacyInit">
     <div id="bodyContent" class="bodyContent">
         <div class="header-content">
-            <img class="header-logo" src="./assets/img/logo-small_white.png" alt="join-logo" onclick="switchPage('summary.html')" />
+            <img class="header-logo" src="./assets/img/logo-small_white.png" alt="join-logo" data-action="switch-page" data-url="summary.html" />
             <div class="header-inner-right">
                 <span class="header-kanban-writing">Kanban Project Management Tool</span>
             </div>
@@ -37,7 +37,7 @@
                 <div class="privacy-wrapper">
                     <div class="h1PrivacyBox">
                         <h1>Privacy Policy</h1>
-                        <img src="./assets/img/icon-arrow_left.png" alt="going-back arrow" onclick="goBack()">
+                        <img src="./assets/img/icon-arrow_left.png" alt="going-back arrow" data-action="go-back">
                     </div>
                     <p>Last updated: April 20, 2024</p>
                     <p>This Privacy Policy describes Our policies and procedures on the collection, use and disclosure

--- a/privacy_external.html
+++ b/privacy_external.html
@@ -21,10 +21,10 @@
     <title>Join - Privacy Policy External</title>
 </head>
 
-<body onload="privacyInit()">
+<body data-init="privacyInit">
     <div id="bodyContent" class="bodyContent">
         <div class="header-content">
-            <img class="header-logo" src="./assets/img/logo-small_white.png" alt="join-logo" onclick="switchPage('index.html')"/>
+            <img class="header-logo" src="./assets/img/logo-small_white.png" alt="join-logo" data-action="switch-page" data-url="index.html"/>
             <div class="header-inner-right">
                 <span class="header-kanban-writing">Kanban Project Management Tool</span>
             </div>
@@ -38,7 +38,7 @@
                 <div class="privacy-wrapper">
                     <div class="h1PrivacyBox">
                         <h1>Privacy Policy</h1>
-                        <img src="./assets/img/icon-arrow_left.png" alt="going-back arrow" onclick="goBack()">
+                        <img src="./assets/img/icon-arrow_left.png" alt="going-back arrow" data-action="go-back">
                     </div>
                     <p>Last updated: April 20, 2024</p>
                     <p>This Privacy Policy describes Our policies and procedures on the collection, use and disclosure

--- a/script.js
+++ b/script.js
@@ -9,6 +9,8 @@ const COOKIEBOT_CONFIG_MAX_RETRIES = 30;
 
 initializeLegacyRuntimeFallbacks();
 initializeCookiebot();
+initializeUiEventDelegation();
+initializePageOnDomReady();
 
 
 /**
@@ -108,9 +110,330 @@ function initializeLegacyRuntimeFallbacks() {
 	}
 }
 
+const UI_CLICK_ACTIONS = {
+	"add-contact-card": () => executeNamedFunction("addContactCard"),
+	"add-new-user": () => executeNamedFunction("addNewUser"),
+	"assign-contact-to-task": (element) =>
+		executeNamedFunction("assignContactToTask", [toSafeInteger(element.dataset.contactId)]),
+	"choose-category": (element) =>
+		executeNamedFunction("chooseCategory", [element.dataset.category || ""]),
+	"clear-formular": () => executeNamedFunction("clearFormular"),
+	"close-card": () => executeNamedFunction("closeCard"),
+	"create-task": () => executeNamedFunction("createTask"),
+	"close-edit-delete": () => executeNamedFunction("closeEditDelete"),
+	"close-overlay": (element) =>
+		executeNamedFunction("closeOverlay", [element.dataset.overlayId || ""]),
+	"delete-subtask": (element) =>
+		executeNamedFunction("deleteSubtask", [toSafeInteger(element.dataset.subtaskId)]),
+	"edit-contact": (element) =>
+		executeNamedFunction("editContact", [toSafeInteger(element.dataset.contactId)]),
+	"edit-subtask": (element) =>
+		executeNamedFunction("editSubtask", [toSafeInteger(element.dataset.subtaskId)]),
+	"go-back": () => executeNamedFunction("goBack"),
+	"goto-signup": () => executeNamedFunction("gotoSignUp"),
+	"hide-add-task-container": () => executeNamedFunction("hideAddTaskContainer"),
+	"login-guest": () => executeNamedFunction("loginAsGuest"),
+	"logout": () => executeNamedFunction("logout"),
+	"open-add-task-container": (element) =>
+		executeNamedFunction("showAddTaskContainer", [element.dataset.category || "category-0"]),
+	"open-card": (element) =>
+		executeNamedFunction("openCard", [toSafeInteger(element.dataset.taskId)]),
+	"open-card-delete": (element) =>
+		executeNamedFunction("openCardDelete", [toSafeInteger(element.dataset.taskId)]),
+	"open-card-edit": (element) =>
+		executeNamedFunction("openCardEdit", [toSafeInteger(element.dataset.taskId)]),
+	"open-due-date-picker": () => executeNamedFunction("addTaskDueDateOpenCalendear"),
+	"open-edit-delete": () => executeNamedFunction("openEditDelete"),
+	"open-help": () => executeNamedFunction("openHelp"),
+	"open-new-tab": (element) =>
+		executeNamedFunction("switchPageNewTab", [element.dataset.url || ""]),
+	"open-small-menu": () => executeNamedFunction("openSmallMenu"),
+	"open-filepicker": () => executeNamedFunction("openFilepicker"),
+	"open-contact-details": (element) =>
+		executeNamedFunction("openContactDetails", [
+			toSafeInteger(element.dataset.contactId),
+		]),
+	"redirect-to-login": () => executeNamedFunction("redirectToLogin"),
+	"remove-contact": (element) =>
+		executeNamedFunction("removeContact", [toSafeInteger(element.dataset.contactId)]),
+	"render-subtask-input-field": () =>
+		executeNamedFunction("renderSubtaskInputField"),
+	"save-edit-subtask": (element) =>
+		executeNamedFunction("saveEditSubtask", [toSafeInteger(element.dataset.subtaskId)]),
+	"save-edited-task": (element) =>
+		executeNamedFunction("saveEditedTask", [toSafeInteger(element.dataset.taskId)]),
+	"search-task": () => executeNamedFunction("searchTask"),
+	"set-priority": (element) =>
+		executeNamedFunction("setPriority", [String(element.dataset.priority || "")]),
+	"subtask-add-or-cancel": (element) =>
+		executeNamedFunction("subtaskAddOrCancel", [element.dataset.option || ""]),
+	"switch-page": (element) =>
+		executeNamedFunction("switchPage", [element.dataset.url || ""]),
+	"toggle-addtask-dropdown": (element) =>
+		executeNamedFunction("renderArrow", [
+			element.dataset.arrowContainer || "",
+			element.dataset.contentContainer || "",
+		]),
+	"toggle-privacy-policy-checkbox": () =>
+		executeNamedFunction("togglePrivacyPolicyCheckbox"),
+	"toggle-remember-me": () => executeNamedFunction("toggleRememberMeCheckbox"),
+};
+
+const UI_DRAGSTART_ACTIONS = {
+	"start-dragging": (element) =>
+		executeNamedFunction("startDragging", [toSafeInteger(element.dataset.taskId)]),
+};
+
+const UI_DRAGEND_ACTIONS = {
+	"stop-dragging": () => executeNamedFunction("stopDragging"),
+};
+
+const UI_DRAGOVER_ACTIONS = {
+	"allow-drop": (_, event) => executeNamedFunction("allowDrop", [event]),
+};
+
+const UI_DROP_ACTIONS = {
+	"move-to": (element) =>
+		executeNamedFunction("moveTo", [element.dataset.category || ""]),
+};
+
+const UI_SUBMIT_ACTIONS = {
+	"add-new-user": () => executeNamedFunction("addNewUser"),
+	"login-user": () => executeNamedFunction("loginUser"),
+	"save-contact": () => executeNamedFunction("saveContact"),
+	"save-edited-contact": (formElement) =>
+		executeNamedFunction("saveEditedContact", [
+			toSafeInteger(formElement.dataset.contactId),
+		]),
+};
+
+const UI_KEYUP_ACTIONS = {
+	"search-task": () => executeNamedFunction("searchTask"),
+};
+
+const UI_MOUSEOVER_ACTIONS = {
+	"change-cancel-icon": () => executeNamedFunction("changeCancelIcon"),
+};
+
+const UI_MOUSEOUT_ACTIONS = {
+	"restore-cancel-icon": () => executeNamedFunction("restoreCancelIcon"),
+};
+
+const UI_DBLCLICK_ACTIONS = {
+	"edit-subtask": (element) =>
+		executeNamedFunction("editSubtask", [toSafeInteger(element.dataset.subtaskId)]),
+};
+
+function initializeUiEventDelegation() {
+	document.addEventListener("click", handleDelegatedClick);
+	document.addEventListener("submit", handleDelegatedSubmit);
+	document.addEventListener("keyup", handleDelegatedKeyup);
+	document.addEventListener("dblclick", handleDelegatedDblclick);
+	document.addEventListener("mouseover", handleDelegatedMouseover);
+	document.addEventListener("mouseout", handleDelegatedMouseout);
+	document.addEventListener("dragstart", handleDelegatedDragstart);
+	document.addEventListener("dragend", handleDelegatedDragend);
+	document.addEventListener("dragover", handleDelegatedDragover);
+	document.addEventListener("drop", handleDelegatedDrop);
+}
+
+function initializePageOnDomReady() {
+	const runPageInit = () => {
+		const initFunctionName = document.body?.dataset?.init;
+		if (!initFunctionName) {
+			return;
+		}
+		executeNamedFunction(initFunctionName);
+	};
+
+	if (document.readyState === "loading") {
+		document.addEventListener("DOMContentLoaded", runPageInit, { once: true });
+		return;
+	}
+
+	runPageInit();
+}
+
+function handleDelegatedClick(event) {
+	const stopPropagationElement = event.target.closest(
+		'[data-stop-propagation="true"]'
+	);
+	if (stopPropagationElement) {
+		event.stopPropagation();
+	}
+
+	const actionElement = event.target.closest("[data-action]");
+	if (!actionElement) {
+		return;
+	}
+
+	const actionHandler = UI_CLICK_ACTIONS[actionElement.dataset.action];
+	if (!actionHandler) {
+		return;
+	}
+
+	if (shouldPreventDefault(actionElement)) {
+		event.preventDefault();
+	}
+
+	actionHandler(actionElement, event);
+}
+
+function handleDelegatedSubmit(event) {
+	const formElement = event.target.closest("form[data-submit-action]");
+	if (!formElement) {
+		return;
+	}
+
+	event.preventDefault();
+	const submitHandler = UI_SUBMIT_ACTIONS[formElement.dataset.submitAction];
+	if (!submitHandler) {
+		return;
+	}
+
+	submitHandler(formElement, event);
+}
+
+function handleDelegatedKeyup(event) {
+	const keyupElement = event.target.closest("[data-keyup-action]");
+	if (!keyupElement) {
+		return;
+	}
+
+	const keyupHandler = UI_KEYUP_ACTIONS[keyupElement.dataset.keyupAction];
+	if (!keyupHandler) {
+		return;
+	}
+
+	keyupHandler(keyupElement, event);
+}
+
+function handleDelegatedDblclick(event) {
+	const dblclickElement = event.target.closest("[data-dblclick-action]");
+	if (!dblclickElement) {
+		return;
+	}
+
+	const dblclickHandler =
+		UI_DBLCLICK_ACTIONS[dblclickElement.dataset.dblclickAction];
+	if (!dblclickHandler) {
+		return;
+	}
+
+	dblclickHandler(dblclickElement, event);
+}
+
+function handleDelegatedMouseover(event) {
+	const hoverElement = event.target.closest("[data-hover-action]");
+	if (!hoverElement || hoverElement.contains(event.relatedTarget)) {
+		return;
+	}
+
+	const hoverHandler = UI_MOUSEOVER_ACTIONS[hoverElement.dataset.hoverAction];
+	if (!hoverHandler) {
+		return;
+	}
+
+	hoverHandler(hoverElement, event);
+}
+
+function handleDelegatedMouseout(event) {
+	const leaveElement = event.target.closest("[data-leave-action]");
+	if (!leaveElement || leaveElement.contains(event.relatedTarget)) {
+		return;
+	}
+
+	const leaveHandler = UI_MOUSEOUT_ACTIONS[leaveElement.dataset.leaveAction];
+	if (!leaveHandler) {
+		return;
+	}
+
+	leaveHandler(leaveElement, event);
+}
+
+function handleDelegatedDragstart(event) {
+	const dragstartElement = event.target.closest("[data-dragstart-action]");
+	if (!dragstartElement) {
+		return;
+	}
+
+	const dragstartHandler =
+		UI_DRAGSTART_ACTIONS[dragstartElement.dataset.dragstartAction];
+	if (!dragstartHandler) {
+		return;
+	}
+
+	dragstartHandler(dragstartElement, event);
+}
+
+function handleDelegatedDragend(event) {
+	const dragendElement = event.target.closest("[data-dragend-action]");
+	if (!dragendElement) {
+		return;
+	}
+
+	const dragendHandler = UI_DRAGEND_ACTIONS[dragendElement.dataset.dragendAction];
+	if (!dragendHandler) {
+		return;
+	}
+
+	dragendHandler(dragendElement, event);
+}
+
+function handleDelegatedDragover(event) {
+	const dragoverElement = event.target.closest("[data-dragover-action]");
+	if (!dragoverElement) {
+		return;
+	}
+
+	const dragoverHandler =
+		UI_DRAGOVER_ACTIONS[dragoverElement.dataset.dragoverAction];
+	if (!dragoverHandler) {
+		return;
+	}
+
+	dragoverHandler(dragoverElement, event);
+}
+
+function handleDelegatedDrop(event) {
+	const dropElement = event.target.closest("[data-drop-action]");
+	if (!dropElement) {
+		return;
+	}
+
+	const dropHandler = UI_DROP_ACTIONS[dropElement.dataset.dropAction];
+	if (!dropHandler) {
+		return;
+	}
+
+	dropHandler(dropElement, event);
+}
+
+function shouldPreventDefault(element) {
+	if (element.dataset.preventDefault === "true") {
+		return true;
+	}
+
+	if (element.tagName === "A") {
+		const href = element.getAttribute("href");
+		return href === "#";
+	}
+
+	return false;
+}
+
+function executeNamedFunction(functionName, args = []) {
+	const callback = window[functionName];
+	if (typeof callback !== "function") {
+		console.warn(`UI action handler not found: ${functionName}`);
+		return;
+	}
+	callback(...args);
+}
+
 
 /**
- * the init-function in body onload
+ * Legacy initializer retained for older call sites.
  */
 async function init() {
 	includeHTML();

--- a/signUp.html
+++ b/signUp.html
@@ -26,20 +26,20 @@
             <img class="signUpLogo" src="./assets/img/logo-medium_white.png" alt="logo">
           </header>
           <div class="signUp-box">
-            <button type="button" class="arrowLeft" onclick="redirectToLogin()" aria-label="Back to login">
+            <button type="button" class="arrowLeft" data-action="redirect-to-login" aria-label="Back to login">
               <img src="./assets/img/icon-arrow_left.png" alt="arrow left">
             </button>
             <div class="h1SignUpBox">
               <h1 class="signUpH1">Sign up</h1>
               <div class="horizontalH1UnderlineSignUp"></div>
             </div>
-            <form class="formDiv" id="login-form" onsubmit="return false">
+            <form class="formDiv" id="login-form" data-submit-action="add-new-user">
               <div class="innerSignUpBox">
                 <!-- Wrapper für Name-Feld -->
                 <div class="input-wrapper">
                   <div class="signUpInputField">
                     <label class="sr-only" for="signUpNameInput">Name</label>
-                    <input type="text" id="signUpNameInput" placeholder="Name" aria-describedby="signUpNameError" aria-invalid="false" autocomplete="name" onkeyup="checkIfFormIsValid()" required>
+                    <input type="text" id="signUpNameInput" placeholder="Name" aria-describedby="signUpNameError" aria-invalid="false" autocomplete="name" required>
                     <div class="mailIcon">
                       <img src="./assets/img/icon-person.png" alt="letter">
                     </div>
@@ -52,7 +52,7 @@
                 <div class="input-wrapper">
                   <div class="signUpInputField">
                     <label class="sr-only" for="signUpEmailInput">Email</label>
-                    <input type="email" id="signUpEmailInput" placeholder="Email" aria-describedby="signUpEmailError" aria-invalid="false" autocomplete="email" onkeyup="checkIfFormIsValid()" required>
+                    <input type="email" id="signUpEmailInput" placeholder="Email" aria-describedby="signUpEmailError" aria-invalid="false" autocomplete="email" required>
                     <div class="mailIcon">
                       <img src="./assets/img/icon-mail.png" alt="letter">
                     </div>
@@ -64,7 +64,7 @@
                 <div class="input-wrapper">
                   <div class="signUpInputField">
                     <label class="sr-only" for="signUpPasswordInput">Password</label>
-                    <input type="password" id="signUpPasswordInput" placeholder="Password" aria-describedby="signUpPasswordError" aria-invalid="false" autocomplete="new-password" onkeyup="checkIfFormIsValid()" required>
+                    <input type="password" id="signUpPasswordInput" placeholder="Password" aria-describedby="signUpPasswordError" aria-invalid="false" autocomplete="new-password" required>
                     <div class="mailIcon">
                       <img src="./assets/img/icon-lock.png" alt="lock">
                     </div>
@@ -76,7 +76,7 @@
                 <div class="input-wrapper">
                   <div class="signUpInputField">
                     <label class="sr-only" for="signUpPasswordInputConfirm">Confirm password</label>
-                    <input type="password" id="signUpPasswordInputConfirm" placeholder="Confirm Password" aria-describedby="signUpPasswordConfirmError" aria-invalid="false" autocomplete="new-password" onkeyup="checkIfFormIsValid()" required>
+                    <input type="password" id="signUpPasswordInputConfirm" placeholder="Confirm Password" aria-describedby="signUpPasswordConfirmError" aria-invalid="false" autocomplete="new-password" required>
                     <div class="mailIcon">
                       <img src="./assets/img/icon-lock.png" alt="lock">
                     </div>
@@ -86,24 +86,24 @@
 
                 <!-- Checkbox für Privacy Policy -->
                 <div class="checkboxBox">
-                  <input type="checkbox" id="privacyCheckbox" style="display: none;" onclick="togglePrivacyPolicyCheckbox()">
+                  <input type="checkbox" id="privacyCheckbox" style="display: none;" data-action="toggle-privacy-policy-checkbox">
                   <label for="privacyCheckbox" class="custom-checkbox">
                     <img id="checkboxImage" src="./assets/img/icon-check_button_unchecked.png" alt="checkbox image">
                     I accept the <a href="#">Privacy Policy</a>
                   </label>
                   <br>
                 </div>
-                <button id="registerBtn" class="signUpButtons registerBtn" onclick="addNewUser()" disabled>Sign up</button>
+                <button type="submit" id="registerBtn" class="signUpButtons registerBtn" disabled>Sign up</button>
               </div>
             </form>
           </div>
           <div class="signUpFooter">
-            <div class="privacyPolicySignUp" onclick="switchPageNewTab('privacy_external.html');" target="_blank">
+            <button type="button" class="privacyPolicySignUp" data-action="open-new-tab" data-url="privacy_external.html">
               <span>Privacy policy</span>
-            </div>
-            <div class="legalNoticeSignUp" onclick="switchPageNewTab('legal_notice_external.html');" target="_blank">
+            </button>
+            <button type="button" class="legalNoticeSignUp" data-action="open-new-tab" data-url="legal_notice_external.html">
               <span>Legal notice</span>
-            </div>
+            </button>
           </div>
         </div>
       </div>

--- a/summary.html
+++ b/summary.html
@@ -24,7 +24,7 @@
     <title>Join - Summary</title>
 </head>
 
-<body onload="summaryInit()">
+<body data-init="summaryInit">
     <div id="bodyContent" class="bodyContent">
         <header w3-include-html="./assets/templates/header.html" id="header" class="header">
         </header>


### PR DESCRIPTION
## Summary
This PR migrates UI interaction wiring from inline HTML event attributes (`onclick`, `onsubmit`, `ondrag*`, `onload`, etc.) to a centralized delegated event architecture using `addEventListener` and data attributes.

Closes #33.

## What changed
- Added centralized event delegation in `script.js` for:
  - click, submit, keyup, dblclick
  - mouseover, mouseout
  - dragstart, dragend, dragover, drop
- Replaced page-level `body onload` with `data-init` + DOM-ready initialization.
- Migrated board column drag/drop handlers from inline attributes to delegated `data-*` actions.
- Migrated task card drag handlers in templates to delegated `data-drag*` actions.
- Replaced remaining dynamic inline handler assignment in JS (e.g. create-task button wiring) with dataset-based actions.
- Updated affected HTML/templates to keep markup focused on structure and behavior in JS.

## Why
- Decouples markup from behavior.
- Makes event wiring testable and maintainable.
- Reduces hidden regressions from inline-handler overrides.
- Creates a clear single source of truth for interaction logic.

## Validation
- `node --check` passed for updated JS files.
- `npm run lint:templates` passed (duplicate attribute guardrail).
- Inline event attributes were searched and removed from target pages/templates (`onclick`, `onsubmit`, `ondrag*`, `onload`, etc.).

## Risk / Regression focus
Please regression-test core user journeys:
- Board: open card, edit/delete, drag & drop between columns, search.
- Add Task: dropdowns, priority, subtasks, submit flow.
- Contacts: add/edit/delete popup flows.
- Login/Signup and static legal/help navigation actions.
