### PR TITLE
feat(ui): harden mobile layouts and touch targets on key pages

### DIFF
--- a/UI_TOKENS.md
+++ b/UI_TOKENS.md
@@ -44,6 +44,7 @@ Shared spacing tokens:
 - `--ui-space-2xl: 40px`
 - `--ui-space-3xl: 48px`
 - `--ui-space-4xl: 64px`
+- `--ui-touch-target-min: 44px`
 
 Layout helpers:
 
@@ -58,3 +59,4 @@ Layout helpers:
 1. Add/change token values in `assets/css/ui-tokens.css` first.
 2. In JS, always read breakpoints via `getResponsiveBreakpointPx(...)`.
 3. In CSS, avoid introducing new ad-hoc spacing values when an existing token fits.
+4. For mobile controls, keep interactive targets at or above `--ui-touch-target-min`.

--- a/addTask.html
+++ b/addTask.html
@@ -17,6 +17,7 @@
         integrity="sha512-9NawOLzuLE2GD22PJ6IPWXEjPalb/FpdH1qMpgXdaDM+0OfxEV75ZCle6KhZi0vM6ZWvMrNnIZv6YnsL+keVmA==" 
         crossorigin="anonymous" referrerpolicy="no-referrer">
   <link rel="stylesheet" href="assets/css/addTask.css">
+  <link rel="stylesheet" href="./assets/css/mobile-hardening.css">
 
   <!-- Scripts -->
   <script src="script.js"></script>

--- a/assets/css/mobile-hardening.css
+++ b/assets/css/mobile-hardening.css
@@ -1,0 +1,167 @@
+@media (max-width: 801px) {
+  body,
+  .bodyContent,
+  .main-wrapper,
+  .main,
+  .board-Container,
+  .contact-main,
+  .main-summary,
+  .sub-main-summary {
+    overflow-x: hidden;
+    max-width: 100%;
+  }
+
+  .boardTopContainer {
+    flex-wrap: wrap;
+    align-items: stretch;
+    gap: var(--ui-space-md);
+  }
+
+  .searchTaskContainer,
+  .searchTaskInner {
+    width: 100%;
+    min-height: var(--ui-touch-target-min);
+  }
+
+  .searchTaskInner {
+    align-items: center;
+  }
+
+  .searchTaskInner input {
+    min-width: 0;
+  }
+
+  .category,
+  .category-container {
+    min-width: 0;
+    width: 100%;
+  }
+
+  .categoryTasks {
+    max-width: 100%;
+  }
+
+  .searchImg,
+  .addTaskButton,
+  .boardAddTaskCloseHoverContainer,
+  .openCardDeleteContainer,
+  .openCardEditContainer,
+  .addTaskDueDateImage,
+  .subtaskImgDiv,
+  .icon-action-button,
+  .contact-details-back-button {
+    min-width: var(--ui-touch-target-min);
+    min-height: var(--ui-touch-target-min);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .openEditDeleteResponsive,
+  .add-contact-button,
+  .button-add-contact,
+  .cancelButton,
+  .createButton,
+  .icon-edit,
+  .icon-delete,
+  .editDiv,
+  .deleteDiv {
+    min-height: var(--ui-touch-target-min);
+  }
+
+  .addTaskBody,
+  .addTaskBodyLeft {
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+  }
+
+  .addTaskBodyTop,
+  .addTaskBodyBottom {
+    width: min(100%, 440px);
+    max-width: 100%;
+    min-width: 0;
+  }
+
+  .addTaskBtn,
+  .createBtn,
+  .clearBtn,
+  .addTaskPriorityButton,
+  .addTask-dropdown-contact,
+  .addTask-dropdown-category,
+  .subtaskBottom,
+  .uploadImageButton {
+    min-height: var(--ui-touch-target-min);
+  }
+
+  .addTaskPriorityButtonContainer {
+    flex-wrap: wrap;
+    gap: var(--ui-space-sm);
+  }
+
+  .addTaskPriorityButton {
+    flex: 1 1 120px;
+  }
+
+  .button-add-contact-card,
+  .contact-list-letter,
+  .parting-line-container,
+  .parting-line {
+    width: 100%;
+    max-width: 22rem;
+  }
+
+  .contacts-container {
+    padding-inline: var(--ui-space-md);
+  }
+
+  .contact-card {
+    min-height: var(--ui-touch-target-min);
+    align-items: center;
+  }
+
+  .add-contact,
+  .edit-contact {
+    width: 100%;
+    max-width: 100%;
+    left: 0;
+    right: 0;
+    margin-right: 0;
+  }
+
+  .summary-box {
+    gap: var(--ui-space-xl);
+    padding: var(--ui-space-md);
+  }
+}
+
+@media (max-width: 560px) {
+  .openCardContainer,
+  .openCardContainer[editing] {
+    width: calc(100vw - (var(--ui-space-md) * 2));
+    max-width: 100%;
+    margin-inline: auto;
+  }
+
+  .addTaskHoverContainer {
+    left: var(--ui-space-sm);
+    right: var(--ui-space-sm);
+    width: auto;
+    max-width: calc(100vw - (var(--ui-space-sm) * 2));
+  }
+
+  .contact-list {
+    padding-inline: var(--ui-space-sm);
+  }
+
+  .button-container {
+    width: 100%;
+    justify-items: center;
+    padding-inline: var(--ui-space-sm);
+  }
+
+  .urgent,
+  #toDoButton {
+    width: min(100%, 396px);
+  }
+}

--- a/assets/css/ui-tokens.css
+++ b/assets/css/ui-tokens.css
@@ -24,4 +24,5 @@
   --ui-page-inline-phone: 24px;
   --ui-content-gap-md: 15px;
   --ui-content-gap-lg: 20px;
+  --ui-touch-target-min: 44px;
 }

--- a/board.html
+++ b/board.html
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="assets/css/navigation.css" />
     <link rel="stylesheet" href="./assets/css/contacts.css">
     <link rel="stylesheet" href="./assets/css/addTask.css">
+    <link rel="stylesheet" href="./assets/css/mobile-hardening.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/viewerjs/1.11.7/viewer.css" integrity="sha512-9NawOLzuLE2GD22PJ6IPWXEjPalb/FpdH1qMpgXdaDM+0OfxEV75ZCle6KhZi0vM6ZWvMrNnIZv6YnsL+keVmA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <script src="script.js"></script>
 

--- a/contacts.html
+++ b/contacts.html
@@ -14,6 +14,7 @@
     <link rel="stylesheet" href="./assets/css/contacts.css">
 
     <link rel="stylesheet" href="./assets/css/board.css">
+    <link rel="stylesheet" href="./assets/css/mobile-hardening.css">
     <script src="script.js"></script>
     <script src="./js/config.js"></script>
     <script src="./js/storage.js"></script>

--- a/summary.html
+++ b/summary.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="assets/css/navigation.css" />
     <link rel="stylesheet" href="assets/css/summary.css">
     <link rel="stylesheet" href="assets/css/button.css">
+    <link rel="stylesheet" href="./assets/css/mobile-hardening.css">
     <link rel="shortcut icon" href="./assets/img/favicon.png" type="image/png">
 
     <script src="script.js"></script>


### PR DESCRIPTION
## Summary
This PR performs a focused mobile UI audit/hardening pass across key pages (`board`, `addTask`, `contacts`, `summary`) to improve touch usability and reduce overflow/clipping risks.

Closes #35.

## What changed
- Added a dedicated mobile hardening stylesheet:
  - `assets/css/mobile-hardening.css`
- Included this stylesheet on key pages:
  - `addTask.html`
  - `board.html`
  - `contacts.html`
  - `summary.html`
- Introduced a shared touch target token:
  - `--ui-touch-target-min: 44px` in `assets/css/ui-tokens.css`
- Documented the touch-target rule in:
  - `UI_TOKENS.md`

## Mobile hardening scope
- Prevented horizontal overflow on core mobile containers.
- Improved mobile layout resilience for board/add-task/contact/summary sections.
- Enforced minimum touch target size for primary mobile controls (buttons, icon actions, menu triggers, edit/delete controls, etc.).
- Improved responsive behavior for dense sections (priority controls, board/search regions, overlays/dialog widths, contact list/action areas, summary button container).

## Why
- Mobile interactions were functional but inconsistent across key workflows.
- Several controls were visually/physically too small for reliable touch use.
- Some containers had higher risk for clipping or unintended horizontal scroll on narrow widths.

## Validation
- `npm run lint:templates` passed.
- Manual QA focus should be on portrait widths in these flows:
  - Board search + add/open/edit task overlay
  - Add Task form controls/subtasks/priority buttons
  - Contacts list/details + mobile action menu + add/edit overlays
  - Summary card grid and CTA interactions

## Notes
- This is a hardening pass via targeted mobile overrides to reduce regression risk.
- Existing unrelated local changes (outside this PR scope) were intentionally left out of the commit.