### PR TITLE
chore(ci): add automated accessibility baseline checks

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -48,3 +48,29 @@ jobs:
         run: |
           set -euo pipefail
           npm run lint:js
+
+  accessibility-baseline:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Run Lighthouse accessibility baseline
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run a11y:ci
+
+      - name: Upload Lighthouse artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-reports-${{ github.run_id }}
+          path: .lighthouseci
+          if-no-files-found: ignore

--- a/ACCESSIBILITY_CHECKS.md
+++ b/ACCESSIBILITY_CHECKS.md
@@ -1,0 +1,42 @@
+# Accessibility Checks
+
+This repository includes an automated Lighthouse accessibility baseline in CI.
+
+## CI job
+
+Workflow: `.github/workflows/pr-tests.yml`
+
+Job: `accessibility-baseline`
+
+Pages checked:
+
+- `index.html`
+- `summary.html`
+- `board.html`
+- `contacts.html`
+- `addTask.html`
+
+Gate:
+
+- `categories:accessibility >= 0.50`
+
+If the score is below the threshold on any checked page, the job fails.
+
+## Run locally
+
+```bash
+npm run a11y:ci
+```
+
+Requirements:
+
+- Node.js 20+
+- Chrome/Chromium available on your machine
+- `python3` available (used to serve local static files during the check)
+
+## How to interpret output
+
+- Lighthouse prints one result per page URL.
+- The accessibility category score is shown for each page.
+- Failing assertions list the page and threshold mismatch.
+- CI uploads `.lighthouseci` artifacts for deeper inspection when needed.

--- a/lighthouserc.cjs
+++ b/lighthouserc.cjs
@@ -1,0 +1,33 @@
+module.exports = {
+  ci: {
+    collect: {
+      startServerCommand: "python3 -m http.server 4173",
+      startServerReadyPattern: "Serving HTTP on",
+      startServerReadyTimeout: 20000,
+      numberOfRuns: 1,
+      settings: {
+        chromeFlags: "--no-sandbox --disable-dev-shm-usage",
+      },
+      url: [
+        "http://127.0.0.1:4173/index.html",
+        "http://127.0.0.1:4173/summary.html",
+        "http://127.0.0.1:4173/board.html",
+        "http://127.0.0.1:4173/contacts.html",
+        "http://127.0.0.1:4173/addTask.html",
+      ],
+    },
+    assert: {
+      assertions: {
+        "categories:accessibility": [
+          "error",
+          {
+            minScore: 0.5,
+          },
+        ],
+      },
+    },
+    upload: {
+      target: "temporary-public-storage",
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "lint:js": "node scripts/lint_page_bundles.cjs",
     "lint:templates": "node scripts/check_duplicate_template_attributes.cjs",
-    "lint": "npm run lint:js && npm run lint:templates"
+    "lint": "npm run lint:js && npm run lint:templates",
+    "a11y:ci": "npx --yes @lhci/cli autorun --config=./lighthouserc.cjs"
   },
   "devDependencies": {
     "eslint": "^8.57.1"


### PR DESCRIPTION
## Summary
This PR adds an automated accessibility baseline check to CI using Lighthouse CI.

Closes #36.

## What changed
- Added a new CI job `accessibility-baseline` to `.github/workflows/pr-tests.yml`
  - Runs on `push` and `pull_request`
  - Executes Lighthouse accessibility checks
  - Uploads Lighthouse artifacts (`.lighthouseci`) for investigation
- Added Lighthouse CI config in `lighthouserc.cjs`
  - Starts a local static server
  - Audits core pages:
    - `index.html`
    - `summary.html`
    - `board.html`
    - `contacts.html`
    - `addTask.html`
  - Enforces baseline gate:
    - `categories:accessibility >= 0.50`
- Added local developer command in `package.json`
  - `npm run a11y:ci`
- Added documentation in `ACCESSIBILITY_CHECKS.md`
  - CI behavior
  - local run instructions
  - how to interpret failures

## Engineering value
- Adds early regression detection for accessibility in PRs.
- Creates measurable baseline for accessibility quality.
- Provides actionable page-level output and artifacts for follow-up fixes.

## Validation
- Workflow and Lighthouse config were validated for structure.
- Template guardrail checks remain green.
- Note: Full local Lighthouse execution in this environment was blocked by network constraints when fetching npm packages; CI is expected to run normally on GitHub runners.