### PR TITLE
feat(a11y): replace clickable div controls with semantic buttons

### DIFF
--- a/assets/css/addTask.css
+++ b/assets/css/addTask.css
@@ -667,7 +667,7 @@ select {
   flex-direction: row;
   justify-content: space-between;
   font-size: 1rem;
-  cursor: pointer;
+  cursor: default;
   padding: var(--padding-0616);
   border-radius: 10px;
 
@@ -678,6 +678,23 @@ select {
   &:hover .subtaskCheckboxes {
     visibility: visible;
   }
+}
+
+.subtaskTextButton {
+  border: none;
+  background-color: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  padding: 0;
+  cursor: pointer;
+  width: 100%;
+}
+
+.subtaskTextButton:focus-visible {
+  outline: 2px solid var(--clr-contact-marked);
+  outline-offset: 2px;
+  border-radius: 6px;
 }
 
 .subTaskOutputDiv.editing {

--- a/assets/css/contacts.css
+++ b/assets/css/contacts.css
@@ -346,15 +346,17 @@ input::placeholder {
   display: flex;
   width: 22.313rem;
   height: 3.5rem;
-  border: 0.063rem;
+  border: 0.063rem solid #4589ff;
   border-radius: 0.625rem;
-  border-color: #4589ff;
   padding: 1rem 0.625rem 1rem 0.625rem;
   background-color: #4589ff;
   gap: 0.625rem;
   align-items: center;
   justify-content: center;
   cursor: pointer;
+  color: white;
+  font: inherit;
+  text-align: center;
 }
 
 .button-add-contact img {
@@ -376,6 +378,11 @@ input::placeholder {
 .button-add-contact:hover {
   background-color: #005dff;
   scale: 1.1 ;
+}
+
+.button-add-contact:focus-visible {
+  outline: 3px solid #2a3647;
+  outline-offset: 2px;
 }
 
 .contact-list {
@@ -409,12 +416,23 @@ input::placeholder {
   border-radius: 0.625rem;
   padding: 0.938rem 1.5rem 0.938rem 1.5rem;
   gap: 2.188rem;
+  width: 100%;
+  border: none;
+  background-color: transparent;
+  color: inherit;
+  text-align: left;
+  font: inherit;
 }
 
 .contact-card:hover {
   background-color: #4589ff;
   color: white;
   cursor: pointer;
+}
+
+.contact-card:focus-visible {
+  outline: 3px solid #2a3647;
+  outline-offset: 2px;
 }
 
 .contact-card:hover .profile-badge-group {
@@ -539,6 +557,11 @@ input::placeholder {
   align-items: center;
   color: #2a3647;
   cursor: pointer;
+  border: none;
+  background-color: transparent;
+  padding: 0;
+  font-family: inherit;
+  text-align: left;
 }
 
 .icon-edit:hover {
@@ -559,6 +582,11 @@ input::placeholder {
   align-items: center;
   color: #2a3647;
   cursor: pointer;
+  border: none;
+  background-color: transparent;
+  padding: 0;
+  font-family: inherit;
+  text-align: left;
 }
 
 .icon-delete:hover {
@@ -568,6 +596,13 @@ input::placeholder {
 .icon-delete img {
   height: 1.5rem;
   width: 1.5rem;
+}
+
+.icon-edit:focus-visible,
+.icon-delete:focus-visible {
+  outline: 2px solid #2a3647;
+  outline-offset: 2px;
+  border-radius: 6px;
 }
 
 .contact-information {
@@ -996,6 +1031,11 @@ input::placeholder {
     font-size: 16px;
     cursor: pointer;
     padding: 8px;
+    border: none;
+    background-color: transparent;
+    width: 100%;
+    text-align: left;
+    font-family: inherit;
     }
 
     .editDiv:hover {
@@ -1010,11 +1050,23 @@ input::placeholder {
       font-size: 16px;
       cursor: pointer;
       padding: 8px;
+      border: none;
+      background-color: transparent;
+      width: 100%;
+      text-align: left;
+      font-family: inherit;
   }
 }
 
 .deleteDiv:hover {
   scale: 1.1;
+}
+
+.editDiv:focus-visible,
+.deleteDiv:focus-visible {
+  outline: 2px solid #2a3647;
+  outline-offset: 2px;
+  border-radius: 6px;
 }
 
 @media screen and (max-width: 580px) {

--- a/assets/templates/html_templates.js
+++ b/assets/templates/html_templates.js
@@ -562,8 +562,10 @@ function renderSubtaskHTML(outputContainer, subtask) {
   const safeSubtaskText = escapeHtml(subtask && subtask.subtaskText);
 
   outputContainer.innerHTML += /*html*/ `
-        <div class="subTaskOutputDiv" id="subtask${safeSubtaskId}" data-dblclick-action="edit-subtask" data-subtask-id="${safeSubtaskId}">
-        <div class="subtaskText">${safeSubtaskText}</div>
+        <div class="subTaskOutputDiv" id="subtask${safeSubtaskId}">
+        <button type="button" class="subtaskTextButton" data-action="edit-subtask" data-subtask-id="${safeSubtaskId}">
+          <span class="subtaskText">${safeSubtaskText}</span>
+        </button>
             <div class="subtaskCheckboxes">
                 <button type="button" class="subtaskImgDiv pointer" id="subtaskImgEdit" data-action="edit-subtask" data-subtask-id="${safeSubtaskId}" aria-label="Edit subtask"></button>
                 <div class="vLine"></div>

--- a/js/contacts_render.js
+++ b/js/contacts_render.js
@@ -19,10 +19,10 @@ function generateContactsContainerHTML() {
   </button>
   <div class="contacts-container-outer">
     <div class="contacts-container" id="contacts-container"> 
-            <div id="button-add-contact-card" class="button-add-contact" data-action="add-contact-card" data-stop-propagation="true">
-                <div class="add-new-contact">Add new contact</div>
+            <button type="button" id="button-add-contact-card" class="button-add-contact" data-action="add-contact-card" data-stop-propagation="true">
+                <span class="add-new-contact">Add new contact</span>
                 <img src="./assets/img/icon-person_add.png" alt="icon-person_add.png">
-            </div>
+            </button>
         <div class="contact-list" id="contactList">
         </div>
     </div>
@@ -177,13 +177,13 @@ function generateContactCardHTML(
     const safeShorterMail = escapeHtml(shorterMail);
 
     return /*html*/ `
-      <div class="contact-card" id="contact-card-${safeContactId}" data-action="open-contact-details" data-contact-id="${safeContactId}">
+      <button type="button" class="contact-card" id="contact-card-${safeContactId}" data-action="open-contact-details" data-contact-id="${safeContactId}">
         <div class="profile-badge-group" style="background-color: ${safeProfileColor}">${safeInitials}</div>
         <div>
           <span class="contact-card-name">${safeFormattedName}</span><br>
-          <a class="contact-card-email">${safeShorterMail}</a>
+          <span class="contact-card-email">${safeShorterMail}</span>
         </div>
-      </div>
+      </button>
     `;
   }
 
@@ -223,12 +223,12 @@ function generateContactDetailsHTML(name, email, phone, id, color) {
           <div class="contact-details-name-group">
             <div class="contact-details-name">${safeContactName}</div>
             <div class="contact-details-icons">
-              <div class="icon-edit" data-action="edit-contact" data-contact-id="${safeContactId}">
+              <button type="button" class="icon-edit" data-action="edit-contact" data-contact-id="${safeContactId}">
                 <img src="./assets/img/icon-edit.png" alt="">Edit
-              </div>
-              <div class="icon-delete" data-action="remove-contact" data-contact-id="${safeContactId}">
+              </button>
+              <button type="button" class="icon-delete" data-action="remove-contact" data-contact-id="${safeContactId}">
                 <img src="./assets/img/icon-delete.png" alt="">Delete
-              </div>
+              </button>
             </div>
           </div>
         </div>
@@ -248,14 +248,14 @@ function generateContactDetailsHTML(name, email, phone, id, color) {
           <img src="./assets/img/Menu Contact options.png" alt="">
         </button>
         <div class="editDelete d-none" id="editDelete" data-stop-propagation="true">
-          <div class="editDiv" data-action="edit-contact" data-contact-id="${safeContactId}">
+          <button type="button" class="editDiv" data-action="edit-contact" data-contact-id="${safeContactId}">
             <img src="./assets/img/icon-edit.png" alt="">
             <span>Edit</span>
-            </div>
-          <div class="deleteDiv" data-action="remove-contact" data-contact-id="${safeContactId}">
+            </button>
+          <button type="button" class="deleteDiv" data-action="remove-contact" data-contact-id="${safeContactId}">
               <img src="./assets/img/icon-delete.png" alt="">
               <span>Delete</span>
-            </div>
+            </button>
         </div>
       </div>
     `;


### PR DESCRIPTION
## Summary
This PR improves accessibility by replacing non-semantic clickable `div` controls with semantic `button` elements in key interactive templates.

Closes #37.

## What changed
- Replaced clickable `div` elements with semantic `button` elements in contact UI templates:
  - Add-contact CTA container
  - Contact card row trigger
  - Contact action controls (edit/delete)
  - Mobile action menu entries (edit/delete)
- Reworked subtask interaction markup in templates:
  - Replaced interactive subtask text container with a semantic `button` trigger for edit action
- Updated styles to preserve the current visual design after semantic conversion:
  - Added button reset styles where required
  - Added keyboard-visible focus styles (`:focus-visible`) for converted controls

## Files touched
- `js/contacts_render.js`
- `assets/templates/html_templates.js`
- `assets/css/contacts.css`
- `assets/css/addTask.css`

## Why
- Improves semantic correctness and screen-reader compatibility.
- Ensures keyboard users can consistently reach and activate controls (Tab/Enter/Space).
- Reduces reliance on non-semantic click targets that can behave inconsistently across devices.

## Validation
- JS syntax checks passed for updated template/render files.
- Template guardrail check (`npm run lint:templates`) passed.
- Visual behavior preserved via targeted CSS adjustments for converted controls.

## Regression focus
Please verify:
- Contact list: open contact details by keyboard and pointer.
- Contact details: edit/delete actions (desktop + mobile menu).
- Add-contact CTA behavior.
- Subtask edit trigger behavior in add-task/edit-task flows.
- Focus ring visibility and tab order on converted controls.