### PR TITLE
feat(a11y): add focus management for overlays and dropdowns

### DIFF
--- a/js/board_popups.js
+++ b/js/board_popups.js
@@ -10,7 +10,9 @@ function openCard(taskId){
         setAttributes(newDiv, {
             'id': 'openCardContainer',
             'class': 'openCardContainer',
-            'data-stop-propagation': 'true'
+            'data-stop-propagation': 'true',
+            'role': 'dialog',
+            'aria-modal': 'true',
         });
         document.body.appendChild(newDiv);
     }
@@ -95,7 +97,13 @@ function renderContactsToOpenCard(task) {
  */
 function renderBoardAddTaskOverlay(){
     let newDiv = document.createElement('div');
-    setAttributes(newDiv, {'id': 'addTaskHoverContainer', 'class': 'addTaskHoverContainer', 'data-stop-propagation': 'true'});
+    setAttributes(newDiv, {
+        'id': 'addTaskHoverContainer',
+        'class': 'addTaskHoverContainer',
+        'data-stop-propagation': 'true',
+        'role': 'dialog',
+        'aria-modal': 'true',
+    });
     document.body.appendChild(newDiv);
 
     let container = document.getElementById('addTaskHoverContainer');
@@ -153,12 +161,18 @@ function showAddTaskContainer(category='category-0') {
  */
 function hideAddTaskContainer(){
     if(!document.getElementById('addTaskHoverContainer')){
+        if (typeof closeOpenDropdowns === "function") {
+            closeOpenDropdowns({ restoreFocus: false });
+        }
         deactivateFocusLayer({ restoreFocus: true });
         toggleBoardOverlay('disable');
         return;
     }
     if(document.getElementById('addTaskHoverContainer')){
         let container = document.getElementById('addTaskHoverContainer');
+        if (typeof closeOpenDropdowns === "function") {
+            closeOpenDropdowns({ restoreFocus: false });
+        }
         deactivateFocusLayer({ restoreFocus: true });
         container.classList.remove('showBoard');
         container.classList.add('hideBoard');

--- a/js/contacts_render.js
+++ b/js/contacts_render.js
@@ -244,15 +244,15 @@ function generateContactDetailsHTML(name, email, phone, id, color) {
             <div class="contact-phone-container-phone">${safePhone}</div>
           </div>
         </div>
-        <button type="button" class="openEditDeleteResponsive" id="openEditDeleteResponsive" data-action="open-edit-delete" data-stop-propagation="true" aria-label="Open contact actions menu">
+        <button type="button" class="openEditDeleteResponsive" id="openEditDeleteResponsive" data-action="open-edit-delete" data-stop-propagation="true" aria-label="Open contact actions menu" aria-haspopup="menu" aria-controls="editDelete" aria-expanded="false">
           <img src="./assets/img/Menu Contact options.png" alt="">
         </button>
-        <div class="editDelete d-none" id="editDelete" data-stop-propagation="true">
-          <button type="button" class="editDiv" data-action="edit-contact" data-contact-id="${safeContactId}">
+        <div class="editDelete d-none" id="editDelete" role="menu" aria-label="Contact actions" data-stop-propagation="true">
+          <button type="button" class="editDiv" data-action="edit-contact" data-contact-id="${safeContactId}" role="menuitem">
             <img src="./assets/img/icon-edit.png" alt="">
             <span>Edit</span>
             </button>
-          <button type="button" class="deleteDiv" data-action="remove-contact" data-contact-id="${safeContactId}">
+          <button type="button" class="deleteDiv" data-action="remove-contact" data-contact-id="${safeContactId}" role="menuitem">
               <img src="./assets/img/icon-delete.png" alt="">
               <span>Delete</span>
             </button>


### PR DESCRIPTION
## Summary
This PR adds robust keyboard and focus management for overlays and dropdown flows across contacts and board/add-task interactions.

Closes #38.

## What changed
- Improved Add Task dropdown accessibility (`assigned` / `category`):
  - Added Tab/Shift+Tab focus trapping while a dropdown is open.
  - Added reliable Escape-close handling per active dropdown.
  - Ensured focus returns to the dropdown opener after close.
  - Improved ARIA sync (`aria-expanded`, `aria-controls`) for trigger buttons.
- Improved board overlay/dialog semantics:
  - Added `role="dialog"` and `aria-modal="true"` to board task dialogs.
  - Ensured open dropdowns are closed during overlay teardown to avoid stale focus states.
- Improved contacts overlay/dialog semantics:
  - Added `role="dialog"` and `aria-modal="true"` for add/edit contact overlays.
- Added keyboard focus management for the mobile contact action menu:
  - Escape closes the menu.
  - Tab is trapped within menu actions while open.
  - Focus restores to the opener after closing.
- Added ARIA menu semantics for responsive contact actions:
  - Trigger now has `aria-haspopup="menu"`, `aria-controls`, `aria-expanded`.
  - Menu container uses `role="menu"`.
  - Action buttons use `role="menuitem"`.

## Files changed
- `js/addTask.js`
- `js/board_popups.js`
- `js/contact_popups.js`
- `js/contacts_render.js`

## Why
- Overlay/dropdown interactions previously favored pointer usage and allowed focus escape.
- This update makes keyboard behavior deterministic and accessible:
  - focus enters correctly,
  - remains within active UI layer,
  - closes with Escape,
  - restores to opener on close.

## Validation
- JS syntax checks passed for modified files.
- Template guardrail (`npm run lint:templates`) passed.

## Regression focus
Please verify manually:
- Add Task dropdowns (open/close, Tab loop, Escape, focus restore).
- Board add/edit overlays (Escape handling and focus restore).
- Contact add/edit overlays (focus entry + Escape).
- Mobile contact menu (open, Tab loop, Escape, restore to trigger).