### PR TITLE
feat(a11y): add explicit labels and aria error mapping for forms

### DIFF
--- a/assets/css/contacts.css
+++ b/assets/css/contacts.css
@@ -279,6 +279,20 @@ input {
   padding: 16px;
 }
 
+.input-frame input[aria-invalid="true"] {
+  box-shadow: inset 0 -2px 0 #ff8190;
+}
+
+.contact-error-message {
+  display: block;
+  width: 100%;
+  min-height: 18px;
+  margin-top: -16px;
+  font-size: 14px;
+  line-height: 1.3;
+  color: #ff8190;
+}
+
 input::placeholder {
   color: #d1d1d1;
 }

--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -17,11 +17,17 @@
   color: var(--clr-text);
   background-color: var(--clr-main);
   padding: var(--ui-content-gap-lg);
+  .header-logo-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    text-decoration: none;
+  }
   .header-logo {
     width: 46px;
     height: 56px;
     margin-left: 39px;
-    cursor: pointer;
   }
 }
 
@@ -110,8 +116,18 @@
   }
 }
 
-.helpIcon {
+.helpIconButton {
+  border: none;
+  background: transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
+  padding: 0;
+}
+
+.helpIcon {
+  display: block;
 }
 
 @media (max-width: 801px) {
@@ -134,7 +150,7 @@
   .header-kanban-writing {
     display: none;
   }
-  .helpIcon {
+  .helpIconButton {
     display: none;
   }
 

--- a/assets/css/login.css
+++ b/assets/css/login.css
@@ -108,6 +108,19 @@
   gap: 34px;
 }
 
+.loginInputField input[aria-invalid="true"] {
+  color: #2a3647;
+  box-shadow: inset 0 -2px 0 #ff8190;
+}
+
+.login-error-message {
+  width: 100%;
+  min-height: 18px;
+  font-size: 14px;
+  color: #ff8190;
+  line-height: 1.3;
+}
+
 #loginEmailInput,
 #loginPasswordInput {
   border: none;

--- a/assets/templates/header.html
+++ b/assets/templates/header.html
@@ -1,10 +1,13 @@
 <div class="header-content header-mobile">
-  <img class="header-logo" src="./assets/img/logo-small_white.png" alt="join-logo"
-    data-action="switch-page" data-url="summary.html" />
+  <a class="header-logo-link" href="./summary.html" data-action="switch-page" data-url="summary.html" data-prevent-default="true" aria-label="Go to summary page">
+    <img class="header-logo" src="./assets/img/logo-small_white.png" alt="">
+  </a>
   <div class="header-inner-right">
     <span class="header-kanban-writing">Kanban Project Management Tool</span>
-    <img id="helpIcon" class="helpIcon" src="./assets/img/icon-help.png" alt="help" data-action="open-help" />
-    <button id="userInitials" class="header-initials-button" data-action="open-small-menu">
+    <button type="button" id="helpIcon" class="helpIconButton" data-action="open-help" aria-label="Open help page">
+      <img class="helpIcon" src="./assets/img/icon-help.png" alt="">
+    </button>
+    <button type="button" id="userInitials" class="header-initials-button" data-action="open-small-menu" aria-label="Open user menu">
     </button>
   </div>
   <div id="smallMenu" class="small-menu d-none">

--- a/index.html
+++ b/index.html
@@ -48,16 +48,19 @@
                             <div class="innerLoginBox">
                                 <div class="loginInputField">
                                     <label class="sr-only" for="loginEmailInput">Email</label>
-                                    <input type="email" id="loginEmailInput" placeholder="Email" autocomplete="email" required="">
+                                    <input type="email" id="loginEmailInput" placeholder="Email" autocomplete="email" aria-describedby="loginEmailError loginFormError" aria-invalid="false" required="">
                                     <div class="mailIcon"><img src="./assets/img/icon-mail.png" alt="letter">
                                     </div>
                                 </div>
+                                <span id="loginEmailError" class="login-error-message" role="alert" aria-live="polite"></span>
                                 <div class="loginInputField">
                                     <label class="sr-only" for="loginPasswordInput">Password</label>
-                                    <input type="password" id="loginPasswordInput" placeholder="Password" autocomplete="current-password" required="">
+                                    <input type="password" id="loginPasswordInput" placeholder="Password" autocomplete="current-password" aria-describedby="loginPasswordError loginFormError" aria-invalid="false" required="">
                                     <div class="mailIcon"><img src="./assets/img/icon-lock.png" alt="lock">
                                     </div>
                                 </div>
+                                <span id="loginPasswordError" class="login-error-message" role="alert" aria-live="polite"></span>
+                                <span id="loginFormError" class="login-error-message sr-only" role="alert" aria-live="polite"></span>
                                 <button type="button" id="loginCheckbox" class="checkboxBox" data-action="toggle-remember-me"
                                     aria-label="Toggle remember me">
                                     <img id="loginCheckboxImg" src="./assets/img/icon-check_button_unchecked.png"

--- a/js/contacts_render.js
+++ b/js/contacts_render.js
@@ -61,19 +61,22 @@ function renderAddContactsHTML() {
               <form data-submit-action="save-contact" class="add-contact-input-group">
                   <div class="input-frame">
                       <label class="sr-only" for="contactName">Name</label>
-                      <input id="contactName" type="text" placeholder="Name" autocomplete="name" autofocus required>
+                      <input id="contactName" type="text" placeholder="Name" autocomplete="name" aria-describedby="contactNameError" aria-invalid="false" autofocus required>
                       <img src="./assets/img/icon-person.png" alt="">
                   </div>
+                  <span id="contactNameError" class="contact-error-message" role="alert" aria-live="polite"></span>
                   <div class="input-frame">
                       <label class="sr-only" for="contactMail">Email</label>
-                      <input id="contactMail" type="email" placeholder="Email" autocomplete="email" autofocus required>
+                      <input id="contactMail" type="email" placeholder="Email" autocomplete="email" aria-describedby="contactMailError" aria-invalid="false" autofocus required>
                       <img src="./assets/img/icon-mail.png" alt="">
                   </div>
+                  <span id="contactMailError" class="contact-error-message" role="alert" aria-live="polite"></span>
                   <div class="input-frame">
                       <label class="sr-only" for="contactPhone">Phone</label>
-                      <input id="contactPhone" pattern="[0-9]*" type="tel" placeholder="Phone" autocomplete="tel" autofocus required>
+                      <input id="contactPhone" pattern="[0-9]*" type="tel" placeholder="Phone" autocomplete="tel" aria-describedby="contactPhoneError" aria-invalid="false" autofocus required>
                       <img src="./assets/img/icon-call.png" alt="">
                   </div>
+                  <span id="contactPhoneError" class="contact-error-message" role="alert" aria-live="polite"></span>
                   <div id="addContactButton" class="addContactButton">
                       <button type="button" class="cancelButton" data-action="close-overlay" data-overlay-id="addContact" data-hover-action="change-cancel-icon"
                           data-leave-action="restore-cancel-icon">Cancel
@@ -124,19 +127,22 @@ function renderEditContactHTML(id, name, contactColor) {
               <form action="" data-submit-action="save-edited-contact" data-contact-id="${safeContactId}" class="add-contact-input-group">
                   <div class="input-frame">
                       <label class="sr-only" for="contactName">Name</label>
-                      <input id="contactName" type="text" placeholder="Name" autocomplete="name" autofocus required>
+                      <input id="contactName" type="text" placeholder="Name" autocomplete="name" aria-describedby="contactNameError" aria-invalid="false" autofocus required>
                       <img src="./assets/img/icon-person.png" alt="">
                   </div>
+                  <span id="contactNameError" class="contact-error-message" role="alert" aria-live="polite"></span>
                   <div class="input-frame">
                       <label class="sr-only" for="contactMail">Email</label>
-                      <input id="contactMail" type="email" placeholder="Email" autocomplete="email" autofocus required>
+                      <input id="contactMail" type="email" placeholder="Email" autocomplete="email" aria-describedby="contactMailError" aria-invalid="false" autofocus required>
                       <img src="./assets/img/icon-mail.png" alt="">
                   </div>
+                  <span id="contactMailError" class="contact-error-message" role="alert" aria-live="polite"></span>
                   <div class="input-frame">
                       <label class="sr-only" for="contactPhone">Phone</label>
-                      <input id="contactPhone" type="tel" placeholder="Phone" autocomplete="tel" autofocus required>
+                      <input id="contactPhone" type="tel" placeholder="Phone" autocomplete="tel" aria-describedby="contactPhoneError" aria-invalid="false" autofocus required>
                       <img src="./assets/img/icon-call.png" alt="">
                   </div>
+                  <span id="contactPhoneError" class="contact-error-message" role="alert" aria-live="polite"></span>
                   <div id="addContactButton" class="addContactButton">
                       <button type="button" class="cancelButton" data-action="close-overlay" data-overlay-id="editContact" data-hover-action="change-cancel-icon"
                           data-leave-action="restore-cancel-icon">Cancel


### PR DESCRIPTION
## Summary
This PR addresses issue #39 by improving accessibility for forms and icon-only controls.

### What was changed
- Added explicit error associations for login inputs using `aria-describedby` and `aria-invalid`.
- Added live error regions for login form validation feedback.
- Added contact form field error regions (name, email, phone) for both create and edit overlays.
- Implemented contact form validation helpers that set/clear accessible error state consistently.
- Added duplicate-email validation feedback in contact create/edit flows with field-level announcements.
- Converted header icon-only interactions to semantic controls:
  - logo action as a semantic link
  - help action as a semantic button
  - explicit accessible names (`aria-label`) for icon-only controls
- Added visual styles for invalid field state in login and contacts forms.

## Why
Previously, several errors were only shown via generic UI messages and were not programmatically connected to form fields.  
This made screen-reader feedback weaker and reduced form clarity.

## Acceptance Criteria Mapping
- Form fields have explicit labels and accessible error linkage: ✅
- Icon-only controls expose meaningful accessible names: ✅
- Validation errors are announced and connected to inputs: ✅

## Validation
- `node --check js/login.js js/contact_popups.js js/contacts_render.js`
- `npm run lint:templates`

Closes #39
