### PR TITLE
feat(ui): centralize responsive breakpoints and spacing tokens

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -43,6 +43,12 @@ jobs:
           set -euo pipefail
           npm run lint:templates
 
+      - name: Guardrail check for UI breakpoint and spacing token alignment
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run lint:ui-tokens
+
       - name: Guardrail check for undefined/redeclared JS references across page bundles
         shell: bash
         run: |

--- a/UI_TOKENS.md
+++ b/UI_TOKENS.md
@@ -7,6 +7,7 @@ This project now uses shared UI tokens from `assets/css/ui-tokens.css`.
 Canonical responsive breakpoints:
 
 - `--ui-bp-mobile-max: 801px`
+- `--ui-bp-mobile-min: 802px`
 - `--ui-bp-navigation-tablet-max: 950px`
 - `--ui-bp-phone-max: 560px`
 - `--ui-bp-content-narrow-max: 500px`
@@ -14,12 +15,12 @@ Canonical responsive breakpoints:
 
 ### JS usage
 
-Use `getResponsiveBreakpointPx(cssVarName, fallback)` from `script.js`.
+Use `getUiBreakpointValue(key)` from `script.js` for shared keys, and keep `getResponsiveBreakpointPx(...)` as low-level fallback helper.
 
 Example:
 
 ```js
-const mobileMax = getResponsiveBreakpointPx("--ui-bp-mobile-max", 801);
+const mobileMax = getUiBreakpointValue("mobileMax");
 if (window.innerWidth <= mobileMax) {
   // mobile behavior
 }
@@ -36,14 +37,17 @@ Shared spacing tokens:
 
 - `--ui-space-0: 0`
 - `--ui-space-xxs: 4px`
+- `--ui-space-2xs: 6px`
 - `--ui-space-xs: 8px`
 - `--ui-space-sm: 10px`
+- `--ui-space-sm-md: 12px`
 - `--ui-space-md: 16px`
 - `--ui-space-lg: 24px`
 - `--ui-space-xl: 32px`
 - `--ui-space-2xl: 40px`
 - `--ui-space-3xl: 48px`
 - `--ui-space-4xl: 64px`
+- `--ui-space-5xl: 72px`
 - `--ui-touch-target-min: 44px`
 
 Layout helpers:
@@ -57,6 +61,14 @@ Layout helpers:
 ## Rule for future changes
 
 1. Add/change token values in `assets/css/ui-tokens.css` first.
-2. In JS, always read breakpoints via `getResponsiveBreakpointPx(...)`.
+2. In JS, prefer `getUiBreakpointValue(...)` for named core breakpoints (or `getResponsiveBreakpointPx(...)` for low-level access).
 3. In CSS, avoid introducing new ad-hoc spacing values when an existing token fits.
 4. For mobile controls, keep interactive targets at or above `--ui-touch-target-min`.
+
+## Guardrail
+
+Run `npm run lint:ui-tokens` to validate:
+
+- core breakpoint usage in CSS,
+- JS breakpoint fallback alignment,
+- tokenized spacing usage in key UI styles.

--- a/assets/css/addTask.css
+++ b/assets/css/addTask.css
@@ -1,7 +1,7 @@
 :root {
-  --addTaskGap-8: 8px;
-  --addTaskGap-12: 12px;
-  --addTaskGap-24: 24px;
+  --addTaskGap-8: var(--ui-space-xs);
+  --addTaskGap-12: var(--ui-space-sm-md);
+  --addTaskGap-24: var(--ui-space-lg);
   --clr-prio-urgent: #ff3d00;
   --clr-prio-medium: #ffa800;
   --clr-prio-low: #7ae229;
@@ -10,8 +10,8 @@
   --clr-contact-hover: #d2e3ff;
   --clr-border: #d1d1d1;
   --clr-border-hover: var(--clr-contact-marked);
-  --padding-1216: 12px 16px 12px 16px;
-  --padding-0616: 6px 16px 6px 16px;
+  --padding-1216: var(--ui-space-sm-md) var(--ui-space-md);
+  --padding-0616: var(--ui-space-2xs) var(--ui-space-md);
   --clr-btn-border: #647188;
   --addTask-transistion: all 0.1s ease;
 }
@@ -76,7 +76,7 @@ select {
 }
 
 #addTaskDescriptionInput {
-  padding: 18px 16px;
+  padding: 18px var(--ui-space-md);
 }
 
 .addTaskRequired {
@@ -96,7 +96,7 @@ select {
   flex-direction: row;
   width: 100%;
 
-  padding: 20px 0;
+  padding: var(--ui-content-gap-lg) 0;
   font-size: 1.188rem;
   gap: var(--addTaskGap-24);
 
@@ -114,7 +114,7 @@ select {
   flex-direction: column;
   gap: var(--addTaskGap-24);
   overflow-y: auto;
-  padding: 44px 10px 0 24px;
+  padding: 44px var(--ui-space-sm) 0 var(--ui-space-lg);
   cursor: default;
   width: min-content;
 }
@@ -149,7 +149,7 @@ select {
   width: 100px;
   height: 60px;
   border: 1px solid var(--clr-btn-border);
-  padding: 16px 10px 16px 10px;
+  padding: var(--ui-space-md) var(--ui-space-sm);
   border-radius: 10px;
   font-size: 1.438rem;
   transition: var(--addTask-transistion);
@@ -157,7 +157,7 @@ select {
 
 .clearBtn {
   display: flex;
-  gap: 10px;
+  gap: var(--ui-space-sm);
   background-color: #fff;
   color: var(--clr-btn-border);
   cursor: pointer;
@@ -186,7 +186,7 @@ select {
 
 .createBtn {
   display: flex;
-  gap: 4px;
+  gap: var(--ui-space-xxs);
   background-color: var(--clr-contact-marked);
   color: white;
   width: max-content;

--- a/assets/css/board.css
+++ b/assets/css/board.css
@@ -60,10 +60,10 @@
     width: 100%;
     align-items: end;
     margin: 0;
-    padding-bottom: 20px;
+    padding-bottom: var(--ui-content-gap-lg);
     position: relative;
-    bottom: 20px;
-    right: 20px;
+    bottom: var(--ui-content-gap-lg);
+    right: var(--ui-content-gap-lg);
   }
 
   .clearBtn {
@@ -106,7 +106,7 @@
 }
 
 .boardTopContainer {
-  padding: 10px;
+  padding: var(--ui-space-sm);
   display: flex;
   gap: 35px;
 
@@ -147,7 +147,7 @@
   width: 100%;
   justify-content: space-between;
   padding: 8px 16px 8px 16px;
-  gap: 16px;
+  gap: var(--ui-space-md);
   height: 100%;
 
   input {
@@ -168,7 +168,7 @@
 .editCardImagesContainer {
   display: flex;
   flex-wrap: wrap;
-  margin-top: 10px;
+  margin-top: var(--ui-space-sm);
 }
 
 .editThumbnailWrapper {
@@ -225,9 +225,9 @@ button:focus {
   display: grid;
   width: 100%;
   flex-direction: column;
-  padding: 10px;
+  padding: var(--ui-space-sm);
   grid-template-columns: repeat(4, 1fr);
-  gap: 24px;
+  gap: var(--ui-space-lg);
   overflow: scroll;
   height: 100%;
 }
@@ -256,7 +256,7 @@ button:focus {
 
 .categoryTasks {
   display: flex;
-  gap: 16px;
+  gap: var(--ui-space-md);
   justify-content: center;
   align-items: center;
   flex-direction: column;
@@ -283,8 +283,8 @@ button:focus {
   justify-content: space-between;
   width: 100%;
   border-radius: 24px;
-  gap: 24px;
-  padding: 16px;
+  gap: var(--ui-space-lg);
+  padding: var(--ui-space-md);
   box-shadow: 0 0 10px 3px rgba(0, 0, 0, 0.1);
   cursor: pointer;
   width: 252px;
@@ -375,7 +375,7 @@ button:focus {
 .cardBottomContainer {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: var(--ui-space-lg);
 }
 
 .assignedToAndPriority {
@@ -386,7 +386,7 @@ button:focus {
 .cardTopContainer {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: var(--ui-space-lg);
 }
 
 .cardPriority {
@@ -399,7 +399,7 @@ button:focus {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  gap: 16px;
+  gap: var(--ui-space-md);
   align-items: center;
 }
 
@@ -547,7 +547,7 @@ progress {
 .openCardInnerContainer {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: var(--ui-space-lg);
   overflow-y: auto;
   padding-right: 10px;
 }
@@ -598,7 +598,7 @@ progress {
 .openCardAssignedToContact {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: var(--ui-space-md);
   text-transform: capitalize;
   padding: 7px 16px;
   font-size: 1.188rem;
@@ -621,7 +621,7 @@ progress {
   display: flex;
   align-items: center;
   padding: 6px 16px;
-  gap: 16px;
+  gap: var(--ui-space-md);
   font-size: 1rem;
   text-transform: capitalize; /* has to be??  */
 }
@@ -732,7 +732,7 @@ progress {
 
   .openCardContainer[editing] .addTaskBodyRight {
     position: static !important;
-    padding: 16px;
+    padding: var(--ui-space-md);
   }
 
   .addTaskBtn {
@@ -754,7 +754,7 @@ progress {
 
   .category {
     display: flex;
-    gap: 16px;
+    gap: var(--ui-space-md);
     width: 100%;
   }
 
@@ -819,7 +819,7 @@ progress {
   .addTaskHoverContainer {
     position: fixed;
     top: 20px;
-    right: 20px;
+    right: var(--ui-content-gap-lg);
     left: 20px;
     height: 95%;
     border-radius: 30px;
@@ -835,7 +835,7 @@ progress {
       flex-direction: column;
       align-items: center;
       justify-content: flex-start;
-      padding: 10px;
+      padding: var(--ui-space-sm);
       height: 80%;
     }
 
@@ -886,7 +886,7 @@ progress {
 
     .addTaskPriorityButtonContainer {
       justify-content: center;
-      gap: 16px;
+      gap: var(--ui-space-md);
     }
 
     .addTaskPriorityButton {
@@ -954,7 +954,7 @@ progress {
     padding: 5px;
     .boardEditTaskHeader,
     .addTaskBodyRight {
-      padding: 10px;
+      padding: var(--ui-space-sm);
       bottom: 10px;
     }
   }

--- a/assets/css/ui-tokens.css
+++ b/assets/css/ui-tokens.css
@@ -1,6 +1,7 @@
 :root {
-  /* Responsive breakpoints */
+  /* Responsive breakpoints (single source of truth for CSS/JS) */
   --ui-bp-mobile-max: 801px;
+  --ui-bp-mobile-min: 802px;
   --ui-bp-navigation-tablet-max: 950px;
   --ui-bp-phone-max: 560px;
   --ui-bp-content-narrow-max: 500px;
@@ -9,14 +10,17 @@
   /* Spacing scale */
   --ui-space-0: 0;
   --ui-space-xxs: 4px;
+  --ui-space-2xs: 6px;
   --ui-space-xs: 8px;
   --ui-space-sm: 10px;
+  --ui-space-sm-md: 12px;
   --ui-space-md: 16px;
   --ui-space-lg: 24px;
   --ui-space-xl: 32px;
   --ui-space-2xl: 40px;
   --ui-space-3xl: 48px;
   --ui-space-4xl: 64px;
+  --ui-space-5xl: 72px;
 
   /* Layout rhythm */
   --ui-page-inline: 88px;

--- a/js/board.js
+++ b/js/board.js
@@ -474,8 +474,8 @@ function displayEmptyTask(taskId, categoryId){
     let cardWidth = "min-width: "+  document.getElementById(taskId).clientWidth + "px";
     let cardStyle = cardHeight + "; " + cardWidth;
     const boardColumnsMaxWidth =
-      typeof getResponsiveBreakpointPx === "function"
-        ? getResponsiveBreakpointPx("--ui-bp-board-columns-max", 1400)
+      typeof getUiBreakpointValue === "function"
+        ? getUiBreakpointValue("boardColumnsMax")
         : 1400;
 
     let newDiv = document.createElement('div');

--- a/js/summary.js
+++ b/js/summary.js
@@ -199,8 +199,8 @@ function buttonEventListener() {
  */
 function greetUserMobile() {
     const mobileGreetingMaxWidth =
-        typeof getResponsiveBreakpointPx === 'function'
-            ? getResponsiveBreakpointPx('--ui-bp-navigation-tablet-max', 950)
+        typeof getUiBreakpointValue === 'function'
+            ? getUiBreakpointValue('navigationTabletMax')
             : 950;
 
     if (window.innerWidth <= mobileGreetingMaxWidth && document.referrer.includes('index')) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "lint:js": "node scripts/lint_page_bundles.cjs",
     "lint:templates": "node scripts/check_duplicate_template_attributes.cjs",
-    "lint": "npm run lint:js && npm run lint:templates",
+    "lint:ui-tokens": "node scripts/check_ui_tokens_alignment.cjs",
+    "lint": "npm run lint:templates && npm run lint:ui-tokens && npm run lint:js",
     "a11y:ci": "npx --yes @lhci/cli autorun --config=./lighthouserc.cjs"
   },
   "devDependencies": {

--- a/script.js
+++ b/script.js
@@ -9,7 +9,16 @@ const COOKIEBOT_CONFIG_MAX_RETRIES = 30;
 const UI_BREAKPOINT_VARIABLES = Object.freeze({
 	mobileMax: "--ui-bp-mobile-max",
 	navigationTabletMax: "--ui-bp-navigation-tablet-max",
+	phoneMax: "--ui-bp-phone-max",
+	contentNarrowMax: "--ui-bp-content-narrow-max",
 	boardColumnsMax: "--ui-bp-board-columns-max",
+});
+const UI_BREAKPOINT_FALLBACKS = Object.freeze({
+	mobileMax: 801,
+	navigationTabletMax: 950,
+	phoneMax: 560,
+	contentNarrowMax: 500,
+	boardColumnsMax: 1400,
 });
 
 initializeLegacyRuntimeFallbacks();
@@ -605,11 +614,7 @@ function renderStandardNavigation(){
  * @return {void} This function does not return anything.
  */
 function setIsSmallerThan802(){
-	if (isViewportAtMost(UI_BREAKPOINT_VARIABLES.mobileMax, 801)) {
-		isSmallerThan802 = true;
-	} else {
-		isSmallerThan802 = false;
-	}
+	isSmallerThan802 = isUiBreakpointAtMost("mobileMax");
 }
 
 
@@ -640,6 +645,35 @@ function getResponsiveBreakpointPx(cssVariableName, fallbackPx) {
  */
 function isViewportAtMost(cssVariableName, fallbackPx) {
 	return window.innerWidth <= getResponsiveBreakpointPx(cssVariableName, fallbackPx);
+}
+
+
+/**
+ * Resolves a breakpoint value by key from the shared UI breakpoint registry.
+ *
+ * @param {keyof UI_BREAKPOINT_VARIABLES} breakpointKey - Named breakpoint key.
+ * @returns {number} Breakpoint value in pixels.
+ */
+function getUiBreakpointValue(breakpointKey) {
+	const cssVariableName = UI_BREAKPOINT_VARIABLES[breakpointKey];
+	const fallbackPx = UI_BREAKPOINT_FALLBACKS[breakpointKey];
+	if (!cssVariableName || !Number.isFinite(fallbackPx)) {
+		console.warn(`Unknown UI breakpoint key: ${String(breakpointKey)}`);
+		return 0;
+	}
+
+	return getResponsiveBreakpointPx(cssVariableName, fallbackPx);
+}
+
+
+/**
+ * Checks viewport width against a shared UI breakpoint key.
+ *
+ * @param {keyof UI_BREAKPOINT_VARIABLES} breakpointKey - Named breakpoint key.
+ * @returns {boolean} True if viewport width is at/below the breakpoint.
+ */
+function isUiBreakpointAtMost(breakpointKey) {
+	return window.innerWidth <= getUiBreakpointValue(breakpointKey);
 }
 
 
@@ -726,11 +760,10 @@ function showInitials() {
  * Function to handle opening the small menu based on screen width.
  */
 function openSmallMenu() {
-	let screenWidth = window.innerWidth;
 	let smallMenu = getDiv("smallMenu");
 	let smallMenuMobile = getDiv("smallMenuMobile");
 
-	if (screenWidth <= getResponsiveBreakpointPx(UI_BREAKPOINT_VARIABLES.mobileMax, 801)) {
+	if (isUiBreakpointAtMost("mobileMax")) {
 		smallMenu.classList.remove("d-none");
 		smallMenuMobile.classList.toggle("d-none");
 	} else {

--- a/scripts/check_ui_tokens_alignment.cjs
+++ b/scripts/check_ui_tokens_alignment.cjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+
+const TOKEN_FILE = path.resolve(process.cwd(), "assets/css/ui-tokens.css");
+
+const CORE_BREAKPOINT_TOKENS = Object.freeze({
+  mobileMax: "--ui-bp-mobile-max",
+  mobileMin: "--ui-bp-mobile-min",
+  navigationTabletMax: "--ui-bp-navigation-tablet-max",
+  phoneMax: "--ui-bp-phone-max",
+  contentNarrowMax: "--ui-bp-content-narrow-max",
+  boardColumnsMax: "--ui-bp-board-columns-max",
+});
+
+const violations = [];
+
+if (!fs.existsSync(TOKEN_FILE)) {
+  console.error(`Missing token file: ${TOKEN_FILE}`);
+  process.exit(1);
+}
+
+const tokenSource = fs.readFileSync(TOKEN_FILE, "utf8");
+const tokenValues = readBreakpointTokenValues(tokenSource);
+
+const cssChecks = [
+  { file: "assets/css/header.css", kind: "max", token: "mobileMax" },
+  { file: "assets/css/navigation.css", kind: "max", token: "navigationTabletMax" },
+  { file: "assets/css/navigation.css", kind: "max", token: "mobileMax" },
+  { file: "assets/css/navigation.css", kind: "max", token: "phoneMax" },
+  { file: "assets/css/board.css", kind: "max", token: "boardColumnsMax" },
+  { file: "assets/css/board.css", kind: "max", token: "mobileMax" },
+  { file: "assets/css/board.css", kind: "max", token: "phoneMax" },
+  { file: "assets/css/addTask.css", kind: "max", token: "mobileMax" },
+  { file: "assets/css/addTask.css", kind: "max", token: "phoneMax" },
+  { file: "style.css", kind: "max", token: "mobileMax" },
+  { file: "assets/css/legalNotice.css", kind: "max", token: "contentNarrowMax" },
+  { file: "assets/css/privacy.css", kind: "max", token: "contentNarrowMax" },
+  { file: "assets/css/contacts.css", kind: "max", token: "mobileMax" },
+  { file: "assets/css/contacts.css", kind: "min", token: "mobileMin" },
+];
+
+for (const check of cssChecks) {
+  const absolutePath = path.resolve(process.cwd(), check.file);
+  ensureFileContainsBreakpoint(absolutePath, check.kind, tokenValues[check.token], check.token);
+}
+
+assertScriptBreakpointFallbacks(tokenValues);
+assertJsBreakpointUsage();
+assertTokenizedSpacingUsage();
+
+if (violations.length > 0) {
+  console.error("UI token alignment check failed:");
+  for (const violation of violations) {
+    console.error(`- ${violation}`);
+  }
+  process.exit(1);
+}
+
+console.log("UI token alignment guardrail passed.");
+
+function readBreakpointTokenValues(source) {
+  const values = {};
+  for (const [key, tokenName] of Object.entries(CORE_BREAKPOINT_TOKENS)) {
+    const match = source.match(
+      new RegExp(`${escapeForRegex(tokenName)}\\s*:\\s*(\\d+)px\\s*;`)
+    );
+    if (!match) {
+      violations.push(`Missing breakpoint token '${tokenName}' in ui-tokens.css.`);
+      continue;
+    }
+    values[key] = Number(match[1]);
+  }
+  return values;
+}
+
+function ensureFileContainsBreakpoint(filePath, kind, value, tokenKey) {
+  if (!Number.isFinite(value)) {
+    violations.push(
+      `Token '${tokenKey}' could not be resolved to a numeric pixel value.`
+    );
+    return;
+  }
+  if (!fs.existsSync(filePath)) {
+    violations.push(`Missing file for token check: ${relative(filePath)}.`);
+    return;
+  }
+
+  const source = fs.readFileSync(filePath, "utf8");
+  const regex = new RegExp(
+    `@media[^\\n\\r]*\\(${kind}-width:\\s*${value}px\\)`,
+    "i"
+  );
+  if (!regex.test(source)) {
+    violations.push(
+      `${relative(filePath)} is expected to use ${kind}-width: ${value}px (token ${tokenKey}).`
+    );
+  }
+}
+
+function assertScriptBreakpointFallbacks(tokenValues) {
+  const scriptPath = path.resolve(process.cwd(), "script.js");
+  if (!fs.existsSync(scriptPath)) {
+    violations.push("Missing script.js for breakpoint fallback checks.");
+    return;
+  }
+
+  const source = fs.readFileSync(scriptPath, "utf8");
+  for (const [key, value] of Object.entries({
+    mobileMax: tokenValues.mobileMax,
+    navigationTabletMax: tokenValues.navigationTabletMax,
+    phoneMax: tokenValues.phoneMax,
+    contentNarrowMax: tokenValues.contentNarrowMax,
+    boardColumnsMax: tokenValues.boardColumnsMax,
+  })) {
+    if (!Number.isFinite(value)) {
+      continue;
+    }
+    const regex = new RegExp(`\\b${key}\\s*:\\s*${value}\\b`);
+    if (!regex.test(source)) {
+      violations.push(
+        `script.js fallback '${key}' must match token value ${value}px.`
+      );
+    }
+  }
+}
+
+function assertJsBreakpointUsage() {
+  const summaryPath = path.resolve(process.cwd(), "js/summary.js");
+  const boardPath = path.resolve(process.cwd(), "js/board.js");
+
+  ensureFileMatches(
+    summaryPath,
+    /getUiBreakpointValue\(['"]navigationTabletMax['"]\)/,
+    "js/summary.js should read 'navigationTabletMax' via getUiBreakpointValue(...)."
+  );
+  ensureFileMatches(
+    boardPath,
+    /getUiBreakpointValue\(['"]boardColumnsMax['"]\)/,
+    "js/board.js should read 'boardColumnsMax' via getUiBreakpointValue(...)."
+  );
+}
+
+function assertTokenizedSpacingUsage() {
+  const addTaskPath = path.resolve(process.cwd(), "assets/css/addTask.css");
+  ensureFileMatches(
+    addTaskPath,
+    /--addTaskGap-8:\s*var\(--ui-space-xs\);/,
+    "assets/css/addTask.css should map --addTaskGap-8 to --ui-space-xs."
+  );
+  ensureFileMatches(
+    addTaskPath,
+    /--addTaskGap-12:\s*var\(--ui-space-sm-md\);/,
+    "assets/css/addTask.css should map --addTaskGap-12 to --ui-space-sm-md."
+  );
+  ensureFileMatches(
+    addTaskPath,
+    /--addTaskGap-24:\s*var\(--ui-space-lg\);/,
+    "assets/css/addTask.css should map --addTaskGap-24 to --ui-space-lg."
+  );
+}
+
+function ensureFileMatches(filePath, regex, message) {
+  if (!fs.existsSync(filePath)) {
+    violations.push(`Missing file for token check: ${relative(filePath)}.`);
+    return;
+  }
+
+  const source = fs.readFileSync(filePath, "utf8");
+  if (!regex.test(source)) {
+    violations.push(message);
+  }
+}
+
+function escapeForRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function relative(filePath) {
+  return path.relative(process.cwd(), filePath) || filePath;
+}


### PR DESCRIPTION
## Summary
This PR implements issue #42 by centralizing responsive breakpoints and spacing tokens, aligning JS/CSS usage to a shared source of truth, and adding CI guardrails to prevent drift.

## What changed

### 1) Shared token source expanded
- Extended `assets/css/ui-tokens.css` with:
  - `--ui-bp-mobile-min`
  - additional spacing steps (`--ui-space-2xs`, `--ui-space-sm-md`, `--ui-space-5xl`)
- Clarified token intent as the canonical source for responsive and spacing values.

### 2) JS breakpoint alignment to one source
- Added keyed breakpoint registry and fallbacks in `script.js`:
  - `UI_BREAKPOINT_VARIABLES`
  - `UI_BREAKPOINT_FALLBACKS`
  - `getUiBreakpointValue(key)`
  - `isUiBreakpointAtMost(key)`
- Updated usage sites to consume shared keys:
  - `js/summary.js` -> `navigationTabletMax`
  - `js/board.js` -> `boardColumnsMax`
- Simplified existing mobile checks to use the shared helper.

### 3) Spacing standardization in key UI files
- Mapped Add Task local spacing aliases to global UI tokens in `assets/css/addTask.css`.
- Replaced repeated hard-coded spacing values in `assets/css/board.css` with shared `--ui-space-*` / `--ui-content-gap-*` tokens for consistent layout rhythm.

### 4) Guardrail + CI integration
- Added `scripts/check_ui_tokens_alignment.cjs` to validate:
  - expected core breakpoint usage in CSS,
  - JS fallback consistency with token values,
  - key spacing token mappings.
- Added npm script:
  - `lint:ui-tokens`
- Updated CI (`.github/workflows/pr-tests.yml`) to run `lint:ui-tokens` on PRs.

### 5) Documentation
- Updated `UI_TOKENS.md` with the new breakpoint/spacing tokens, JS usage guidance, and the new guardrail command.

## Validation
- `node --check script.js js/summary.js js/board.js scripts/check_ui_tokens_alignment.cjs`
- `npm run lint:ui-tokens`
- `npm run lint:templates`
- `npm run lint:js`

Closes #42
