### PR TITLE
chore(lint): reduce false IDE no-undef markers for global scripts

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -13,7 +13,9 @@ module.exports = {
     Cookiebot: "readonly",
   },
   rules: {
-    "no-undef": "error",
+    // Single-file linting in this multi-script project triggers many false
+    // positives for cross-file globals; bundle lint keeps no-undef enforced.
+    "no-undef": "off",
     "no-redeclare": "error",
   },
 };

--- a/js/login.js
+++ b/js/login.js
@@ -1,3 +1,16 @@
+/* global
+checkIfUserIsRemembered,
+firebaseGetArraySafe,
+FIREBASE_USERS_ID,
+migrateLegacyPlaintextPasswords,
+firebaseUpdateItem,
+normalizeAuthEmail,
+getCurrentUser,
+switchPage,
+verifyPasswordCredentials,
+setCurrentUser,
+showGlobalUserMessage
+*/
 "use strict";
 
 /**

--- a/scripts/lint_page_bundles.cjs
+++ b/scripts/lint_page_bundles.cjs
@@ -21,6 +21,12 @@ async function main() {
   const eslint = new ESLint({
     useEslintrc: true,
     ignore: false,
+    overrideConfig: {
+      rules: {
+        "no-undef": "error",
+        "no-redeclare": "error",
+      },
+    },
   });
 
   const lintResults = [];


### PR DESCRIPTION
## Summary
This branch already contains the fix for duplicate inline event attributes in rendered template HTML (#40).
This update additionally improves local developer experience by reducing false-positive IDE lint markers in our multi-script global architecture.

## What changed
- Kept duplicate-attribute guardrail in place and passing (`lint:templates`).
- Reduced noisy single-file `no-undef` editor markers by adjusting ESLint config for local file linting.
- Preserved strict undefined/redeclare checks in the page-bundle guardrail (`npm run lint:js`) via explicit override config.
- Added explicit global declarations in `js/login.js` for cross-file runtime symbols.

## Why
Our project loads many scripts globally per page.  
Single-file linting reports many false-positive `no-undef` markers, which is distracting during development.
At the same time, we still need strict checks in CI on real page bundles.

## Validation
- `npm run lint:templates` ✅
- `npm run lint:js` ✅

Closes #40
