### PR TITLE
chore(ui): add guardrail against inline event attributes

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -43,6 +43,12 @@ jobs:
           set -euo pipefail
           npm run lint:templates
 
+      - name: Guardrail check for inline event attributes in templates
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run lint:inline-events
+
       - name: Guardrail check for UI breakpoint and spacing token alignment
         shell: bash
         run: |

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "scripts": {
     "lint:js": "node scripts/lint_page_bundles.cjs",
     "lint:templates": "node scripts/check_duplicate_template_attributes.cjs",
+    "lint:inline-events": "node scripts/check_inline_event_handlers.cjs",
     "lint:ui-tokens": "node scripts/check_ui_tokens_alignment.cjs",
-    "lint": "npm run lint:templates && npm run lint:ui-tokens && npm run lint:js",
+    "lint": "npm run lint:templates && npm run lint:inline-events && npm run lint:ui-tokens && npm run lint:js",
     "a11y:ci": "npx --yes @lhci/cli autorun --config=./lighthouserc.cjs"
   },
   "devDependencies": {

--- a/scripts/check_inline_event_handlers.cjs
+++ b/scripts/check_inline_event_handlers.cjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+
+const files = [];
+const roots = [
+  { dir: "js", extensions: [".js"] },
+  { dir: "assets/templates", extensions: [".js", ".html"] },
+];
+
+for (const root of roots) {
+  collectFiles(root.dir, root.extensions);
+}
+
+files.push("script.js");
+collectRootHtmlFiles(".");
+
+const violations = [];
+const tagRegex = /<(?!\/|!)([A-Za-z][\w:-]*)(?=[\s/>])([^<>]*)>/g;
+const inlineEventAttributePattern = /^on[a-z][\w:-]*$/i;
+
+for (const file of files) {
+  if (!fs.existsSync(file)) continue;
+
+  const source = fs.readFileSync(file, "utf8");
+  let match;
+
+  while ((match = tagRegex.exec(source)) !== null) {
+    const attributeText = match[2] || "";
+    const names = parseAttributeNames(attributeText);
+    const inlineEventAttributes = names.filter((name) =>
+      inlineEventAttributePattern.test(name)
+    );
+
+    if (inlineEventAttributes.length > 0) {
+      const lineNumber = source.slice(0, match.index).split(/\r?\n/).length;
+      const compactTag = match[0].replace(/\s+/g, " ").trim();
+      violations.push(
+        `${file}:${lineNumber} inline event attribute(s): ${inlineEventAttributes.join(
+          ", "
+        )} | ${compactTag}`
+      );
+    }
+  }
+
+  tagRegex.lastIndex = 0;
+}
+
+if (violations.length > 0) {
+  console.error("Inline event attributes are not allowed:");
+  for (const violation of violations) {
+    console.error(`- ${violation}`);
+  }
+  process.exit(1);
+}
+
+console.log("Inline event attribute guardrail passed.");
+
+function collectFiles(dir, extensions) {
+  if (!fs.existsSync(dir)) return;
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      collectFiles(fullPath, extensions);
+    } else if (
+      entry.isFile() &&
+      extensions.some((extension) => fullPath.endsWith(extension))
+    ) {
+      files.push(fullPath);
+    }
+  }
+}
+
+function collectRootHtmlFiles(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  entries.forEach((entry) => {
+    if (entry.isFile() && entry.name.endsWith(".html")) {
+      files.push(path.join(dir, entry.name));
+    }
+  });
+}
+
+function parseAttributeNames(attributeText) {
+  const names = [];
+  let i = 0;
+
+  while (i < attributeText.length) {
+    while (i < attributeText.length && /\s/.test(attributeText[i])) i++;
+    if (i >= attributeText.length) break;
+
+    if (attributeText[i] === "/") {
+      i++;
+      continue;
+    }
+
+    const start = i;
+    while (i < attributeText.length && !/[\s=/>]/.test(attributeText[i])) {
+      i++;
+    }
+
+    if (i === start) {
+      i++;
+      continue;
+    }
+
+    names.push(attributeText.slice(start, i).toLowerCase());
+
+    while (i < attributeText.length && /\s/.test(attributeText[i])) i++;
+
+    if (i < attributeText.length && attributeText[i] === "=") {
+      i++;
+      while (i < attributeText.length && /\s/.test(attributeText[i])) i++;
+
+      if (
+        i < attributeText.length &&
+        (attributeText[i] === '"' || attributeText[i] === "'")
+      ) {
+        const quote = attributeText[i];
+        i++;
+        while (i < attributeText.length && attributeText[i] !== quote) i++;
+        if (i < attributeText.length && attributeText[i] === quote) i++;
+      } else {
+        while (i < attributeText.length && !/[\s>]/.test(attributeText[i])) i++;
+      }
+    }
+  }
+
+  return names;
+}


### PR DESCRIPTION
## Summary
This PR completes ticket #41 by enforcing the addEventListener/event-delegation architecture and preventing regressions to inline event attributes.

## What changed
- Added a new guardrail script that scans rendered template sources and root HTML files for inline event attributes (e.g. `onclick`, `onmouseover`, `onmouseout`, etc.).
- Added `npm run lint:inline-events`.
- Integrated the new inline-event guardrail into PR CI workflow (`PR Tests`).

## Why
Inline event attributes tightly couple markup and behavior and are hard to maintain/test.
This project already uses centralized event delegation (`data-action` + delegated listeners).  
The new guardrail ensures we do not regress back to inline handlers.

## Acceptance Criteria mapping
- Core flows do not depend on inline event attributes: ✅
- Event registration remains centralized and testable: ✅
- Guardrail check added to prevent future inline event usage: ✅

## Validation
- `npm run lint:inline-events`
- `npm run lint:templates`
- `npm run lint:js`

Closes #41
