### PR TITLE
fix(ui): harden mobile layout overflow and touch targets

### DIFF
--- a/assets/css/mobile-hardening.css
+++ b/assets/css/mobile-hardening.css
@@ -1,4 +1,10 @@
 @media (max-width: 801px) {
+  html,
+  body {
+    max-width: 100%;
+    overflow-x: hidden;
+  }
+
   body,
   .bodyContent,
   .main-wrapper,
@@ -8,6 +14,20 @@
   .main-summary,
   .sub-main-summary {
     overflow-x: hidden;
+    max-width: 100%;
+  }
+
+  .main > *,
+  #addTaskBody,
+  .greetingContainer-and-subMainSummary,
+  .button-container,
+  .contacts-container,
+  .contact-list,
+  .contact-card,
+  .right-side,
+  .openCardContainer,
+  .openCardContainer[editing] {
+    min-width: 0;
     max-width: 100%;
   }
 
@@ -60,6 +80,9 @@
   .openEditDeleteResponsive,
   .add-contact-button,
   .button-add-contact,
+  .addTaskBtn,
+  .addTaskBtnBoard,
+  .dropdownOption,
   .cancelButton,
   .createButton,
   .icon-edit,
@@ -118,6 +141,8 @@
   .contact-card {
     min-height: var(--ui-touch-target-min);
     align-items: center;
+    width: 100%;
+    max-width: 100%;
   }
 
   .add-contact,
@@ -132,6 +157,32 @@
   .summary-box {
     gap: var(--ui-space-xl);
     padding: var(--ui-space-md);
+  }
+
+  .button-container {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    width: 100%;
+    max-width: 100%;
+    gap: var(--ui-space-sm);
+  }
+
+  .square-button,
+  .urgentAndDate,
+  .urgent,
+  #toDoButton {
+    width: 100%;
+    max-width: 396px;
+  }
+
+  .add-contact-button {
+    right: var(--ui-space-md);
+    bottom: calc(var(--ui-space-4xl) + var(--ui-space-md));
+  }
+
+  .editDelete {
+    width: auto;
+    min-width: 160px;
+    right: var(--ui-space-md);
   }
 }
 
@@ -158,6 +209,17 @@
     width: 100%;
     justify-items: center;
     padding-inline: var(--ui-space-sm);
+  }
+
+  .addTaskBodyTop,
+  .addTaskBodyBottom {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .add-contact-button,
+  .editDelete {
+    right: var(--ui-space-sm);
   }
 
   .urgent,

--- a/board.html
+++ b/board.html
@@ -13,11 +13,11 @@
     <link rel="stylesheet" href="assets/css/navigation.css" />
     <link rel="stylesheet" href="./assets/css/contacts.css">
     <link rel="stylesheet" href="./assets/css/addTask.css">
-    <link rel="stylesheet" href="./assets/css/mobile-hardening.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/viewerjs/1.11.7/viewer.css" integrity="sha512-9NawOLzuLE2GD22PJ6IPWXEjPalb/FpdH1qMpgXdaDM+0OfxEV75ZCle6KhZi0vM6ZWvMrNnIZv6YnsL+keVmA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <script src="script.js"></script>
 
     <link rel="stylesheet" href="./assets/css/board.css">
+    <link rel="stylesheet" href="./assets/css/mobile-hardening.css">
     <script src="./js/filepicker.js"></script>
     <script src="./js/board.js"></script>
     <script src="./js/board_popups.js"></script>


### PR DESCRIPTION
## Summary
This PR addresses #43 by hardening mobile layout behavior across key flows (board, add-task, contacts, summary), with focus on overflow prevention, touch-target minimums, and mobile spacing/readability consistency.

## What changed
- Ensured mobile hardening styles are loaded after `board.css` on `board.html` so mobile overrides are not unintentionally overwritten.
- Expanded `assets/css/mobile-hardening.css` with additional mobile safety rules:
  - enforced `overflow-x: hidden` and width constraints for critical layout containers,
  - applied `min-width: 0` / `max-width: 100%` to dense content wrappers,
  - strengthened touch-target minimums for primary interactive controls,
  - improved mobile positioning/sizing for contact floating action elements and action menu,
  - stabilized summary button grid sizing to avoid horizontal overflow on narrow portrait widths.

## Why
The app was mostly desktop-first and had inconsistent mobile behavior in dense views.  
These changes provide a centralized mobile hardening layer that reduces clipping/overflow risk and improves touch usability without changing core business logic.

## Acceptance Criteria Mapping
- No unintended horizontal scrolling on key pages: ✅ addressed via overflow and width hardening.
- Primary interactive elements meet minimum touch target size: ✅ reinforced in mobile hardening.
- Main workflows remain usable on mobile portrait widths: ✅ improved for board/add-task/contacts/summary.

## Validation
- `npm run lint:templates`
- `npm run lint:inline-events`
- `npm run lint:js`

Closes #43
