### PR TITLE
chore(ci): harden automated accessibility baseline checks

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -73,11 +73,26 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Install accessibility check dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install --no-audit --no-fund
+
       - name: Run Lighthouse accessibility baseline
         shell: bash
         run: |
           set -euo pipefail
           npm run a11y:ci
+
+      - name: Print Lighthouse accessibility summary
+        if: always()
+        shell: bash
+        env:
+          A11Y_MIN_SCORE: "0.5"
+        run: |
+          set -euo pipefail
+          npm run a11y:report
 
       - name: Upload Lighthouse artifacts
         if: always()

--- a/ACCESSIBILITY_CHECKS.md
+++ b/ACCESSIBILITY_CHECKS.md
@@ -21,11 +21,14 @@ Gate:
 - `categories:accessibility >= 0.50`
 
 If the score is below the threshold on any checked page, the job fails.
+CI also prints a short page-level summary (PASS/FAIL + top failing audits) in the workflow logs.
 
 ## Run locally
 
 ```bash
+npm install
 npm run a11y:ci
+npm run a11y:report
 ```
 
 Requirements:
@@ -38,5 +41,6 @@ Requirements:
 
 - Lighthouse prints one result per page URL.
 - The accessibility category score is shown for each page.
+- `npm run a11y:report` prints page-level PASS/FAIL against the configured threshold.
 - Failing assertions list the page and threshold mismatch.
 - CI uploads `.lighthouseci` artifacts for deeper inspection when needed.

--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
     "lint:inline-events": "node scripts/check_inline_event_handlers.cjs",
     "lint:ui-tokens": "node scripts/check_ui_tokens_alignment.cjs",
     "lint": "npm run lint:templates && npm run lint:inline-events && npm run lint:ui-tokens && npm run lint:js",
-    "a11y:ci": "npx --yes @lhci/cli autorun --config=./lighthouserc.cjs"
+    "a11y:ci": "lhci autorun --config=./lighthouserc.cjs",
+    "a11y:report": "node scripts/summarize_lighthouse_accessibility.cjs"
   },
   "devDependencies": {
+    "@lhci/cli": "^0.15.1",
     "eslint": "^8.57.1"
   }
 }

--- a/scripts/summarize_lighthouse_accessibility.cjs
+++ b/scripts/summarize_lighthouse_accessibility.cjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+
+const reportDir = path.resolve(".lighthouseci");
+const minScore = Number(process.env.A11Y_MIN_SCORE || "0.5");
+
+function toPathLabel(rawUrl) {
+  try {
+    const url = new URL(rawUrl);
+    return `${url.pathname}${url.search}` || "/";
+  } catch (_error) {
+    return rawUrl || "<unknown>";
+  }
+}
+
+function getFailingAudits(report) {
+  const audits = Object.values(report.audits || {});
+  return audits
+    .filter((audit) => typeof audit.score === "number" && audit.score < 1)
+    .filter((audit) => audit.scoreDisplayMode === "binary" || audit.scoreDisplayMode === "numeric")
+    .sort((left, right) => left.score - right.score)
+    .slice(0, 3);
+}
+
+if (!fs.existsSync(reportDir)) {
+  console.log("No .lighthouseci directory found. Skipping Lighthouse summary.");
+  process.exit(0);
+}
+
+const reportFiles = fs
+  .readdirSync(reportDir)
+  .filter((fileName) => fileName.startsWith("lhr-") && fileName.endsWith(".json"))
+  .sort();
+
+if (reportFiles.length === 0) {
+  console.log("No Lighthouse JSON reports found. Skipping Lighthouse summary.");
+  process.exit(0);
+}
+
+console.log(`Lighthouse accessibility summary (threshold: ${Math.round(minScore * 100)}%)`);
+
+for (const reportFile of reportFiles) {
+  const reportPath = path.join(reportDir, reportFile);
+  let report;
+  try {
+    report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  } catch (error) {
+    console.warn(`- ${reportFile}: failed to parse report JSON (${error.message})`);
+    continue;
+  }
+
+  const page = toPathLabel(report.finalDisplayedUrl || report.requestedUrl);
+  const category = report.categories && report.categories.accessibility;
+
+  if (!category || typeof category.score !== "number") {
+    console.warn(`- ${page}: accessibility score missing`);
+    continue;
+  }
+
+  const scorePercent = Math.round(category.score * 100);
+  const status = category.score >= minScore ? "PASS" : "FAIL";
+  console.log(`- ${page}: ${scorePercent}% (${status})`);
+
+  for (const audit of getFailingAudits(report)) {
+    const title = audit.title || audit.id || "Untitled audit";
+    const score = Math.round((audit.score || 0) * 100);
+    console.log(`  -> ${title} (${score}%)`);
+  }
+}


### PR DESCRIPTION
## Summary
- harden the PR accessibility CI job by installing dependencies before Lighthouse runs
- switch `a11y:ci` to use local `lhci` instead of dynamic `npx` download
- add a new `a11y:report` step to print a concise page-level accessibility summary (PASS/FAIL + top failing audits)
- document local accessibility workflow and interpretation in `ACCESSIBILITY_CHECKS.md`

## Validation
- `npm run lint`
- `npm run a11y:report`

## Notes
- CI keeps uploading `.lighthouseci` artifacts for deeper inspection.
- Lighthouse threshold remains unchanged (`categories:accessibility >= 0.50`).

Closes #44
