### PR TITLE
fix: prevent duplicate mobile viewport declaration in mixed cache states

### DIFF
--- a/js/responsive-navigation.js
+++ b/js/responsive-navigation.js
@@ -1,7 +1,5 @@
 "use strict";
 
-let isMobileViewport = false;
-
 const UI_BREAKPOINT_VARIABLES = Object.freeze({
 	mobileMax: "--ui-bp-mobile-max",
 	navigationTabletMax: "--ui-bp-navigation-tablet-max",
@@ -24,7 +22,7 @@ const UI_BREAKPOINT_FALLBACKS = Object.freeze({
  * @returns {void}
  */
 function initializeResponsiveNavigation() {
-	isMobileViewport = isUiBreakpointAtMost("mobileMax");
+	setIsMobileViewportState(isUiBreakpointAtMost("mobileMax"));
 	runFunctionsOnBreakpoint();
 	addResizeEventListener();
 }
@@ -37,8 +35,8 @@ function initializeResponsiveNavigation() {
 function addResizeEventListener() {
 	window.addEventListener("resize", () => {
 		const nextIsMobileViewport = isUiBreakpointAtMost("mobileMax");
-		if (nextIsMobileViewport !== isMobileViewport) {
-			isMobileViewport = nextIsMobileViewport;
+		if (nextIsMobileViewport !== getIsMobileViewportState()) {
+			setIsMobileViewportState(nextIsMobileViewport);
 			runFunctionsOnBreakpoint();
 		}
 	});
@@ -48,7 +46,7 @@ function addResizeEventListener() {
  * Runs specific functions based on the current breakpoint.
  */
 function runFunctionsOnBreakpoint() {
-	if (isMobileViewport) {
+	if (getIsMobileViewportState()) {
 		renderMobileNavigation();
 		setActiveNavButton();
 	} else {
@@ -134,4 +132,24 @@ function getUiBreakpointValue(breakpointKey) {
  */
 function isUiBreakpointAtMost(breakpointKey) {
 	return window.innerWidth <= getUiBreakpointValue(breakpointKey);
+}
+
+/**
+ * Stores current responsive navigation state on window to avoid lexical global collisions
+ * across mixed cache/deploy states.
+ *
+ * @param {boolean} value - Current mobile breakpoint state.
+ * @returns {void}
+ */
+function setIsMobileViewportState(value) {
+	window.__joinIsMobileViewport = value === true;
+}
+
+/**
+ * Returns current responsive navigation state from window storage.
+ *
+ * @returns {boolean} True if currently in mobile breakpoint mode.
+ */
+function getIsMobileViewportState() {
+	return window.__joinIsMobileViewport === true;
 }

--- a/script.js
+++ b/script.js
@@ -173,6 +173,10 @@ function switchPageNewTab(newUrl) {
 function setActiveNavButton() {
 	const navLinks = ["summary", "addTask", "board", "contacts"];
 	const activeNavLink = document.querySelector(".nav-btn.active");
+	const isMobileViewportActive =
+		typeof getIsMobileViewportState === "function"
+			? getIsMobileViewportState()
+			: false;
 
 	// Remove active class from any previously active nav link
 	if (activeNavLink) {
@@ -182,7 +186,7 @@ function setActiveNavButton() {
 		navLinks.forEach((link) => {
 			if (location.pathname.includes(link)) {
 				document.getElementById(link).classList.add("active");
-				if (isMobileViewport) document.getElementById(link).querySelector("img").src = `./assets/img/icon-${link}-marked.png`;
+				if (isMobileViewportActive) document.getElementById(link).querySelector("img").src = `./assets/img/icon-${link}-marked.png`;
 				else document.getElementById(link).querySelector("img").src = `./assets/img/icon-${link}.png`;
 			}
 		});


### PR DESCRIPTION
## Summary
This PR fixes a production-breaking login/runtime error caused by mixed-cache script combinations.

## Problem
On `index.html` (and other pages), the app could fail with:

`Uncaught SyntaxError: Identifier 'isMobileViewport' has already been declared`

This happened when an older cached runtime script and the newer refactored responsive module were loaded together.

## What changed
- Removed direct global `let isMobileViewport` dependency in responsive navigation.
- Switched responsive state handling to a cache-safe global state key on `window`:
  - `setIsMobileViewportState(...)`
  - `getIsMobileViewportState()`
- Updated `setActiveNavButton()` in `script.js` to read responsive state via the new getter.

## Why this fixes it
Using a single `window`-based state value avoids duplicate lexical declarations across mixed deploy/cache states, so runtime initialization no longer crashes.

## Validation
- `npm run lint` passes:
  - duplicate template attributes
  - inline event guardrail
  - UI token alignment
  - JS bundle lint

Closes #90