### PR TITLE
fix: guard filepicker init when add-task image UI is not rendered

### DIFF
--- a/js/filepicker.js
+++ b/js/filepicker.js
@@ -12,6 +12,12 @@ setTimeout(() => {
 }, 1000);
 
 function initializeFilepickerUI() {
+  if (!hasRenderedAddTaskImageUi()) {
+    observeDropArea();
+    observeContainer();
+    return;
+  }
+
   addFilepickerListener();
   setupDragAndDrop();
   renderAddTaskImages();
@@ -208,7 +214,6 @@ function addImageToArray(file, compressedbase64) {
 function renderAddTaskImages() {
   const container = getCurrentImageContainer();
   if (!container) {
-    console.warn("Kein Container vorhanden zum Rendern der Bilder.");
     return;
   }
   container.innerHTML = "";
@@ -274,8 +279,6 @@ function getCurrentImageContainer() {
 
   if (editContainer) return editContainer;
   if (standardContainer) return standardContainer;
-
-  console.warn("Kein Container gefunden! Erstelle neuen Container 'subtasksImageContainer' innerhalb von 'addImageBottom'.");
   
   const dropArea = document.getElementById("addImageBottom");
   if (dropArea) {
@@ -284,6 +287,16 @@ function getCurrentImageContainer() {
     dropArea.appendChild(newContainer);
     return newContainer;
   } 
+
+  return null;
+}
+
+function hasRenderedAddTaskImageUi() {
+  return Boolean(
+    document.getElementById("subtasksImageContainer") ||
+      document.getElementById("editCardImagesContainer") ||
+      document.getElementById("addImageBottom")
+  );
 }
 
 function observeContainer() {


### PR DESCRIPTION
80-p1refactor-decompose-addtaskjs-into-domain-and-ui-modules

## Summary
This PR delivers a post-merge fix for the board/add-task image uploader initialization to prevent noisy console warnings when the add-task image UI is not yet rendered.

## Problem
On `board.html`, `filepicker.js` initialized immediately and tried to render image containers before the add-task overlay existed, resulting in console messages like:
- `Kein Container gefunden! ...`
- `Kein Container vorhanden zum Rendern der Bilder.`

## What changed
- Updated `initializeFilepickerUI()` to guard initialization until add-task image UI is actually present.
- Added a UI presence check (`hasRenderedAddTaskImageUi()`).
- Kept observer-based deferred setup so initialization still happens automatically once the UI appears.
- Updated `getCurrentImageContainer()` to return `null` safely when no container is available.
- Removed unnecessary warning logs for expected pre-render states.

## Why
Board page load without open add-task overlay is a valid state. Initialization should be deferred, not treated as an error.

## Validation
- `npm run lint` passes.
- Manual expected behavior:
  - Board loads without the previous container warnings.
  - Add-task overlay still initializes upload and image rendering correctly.

## Scope
- File touched: `js/filepicker.js` only.

(Hotfix after prior merge of #80)