### PR TITLE
fix: prevent board overlay lock after unchanged task edit

### DIFF
--- a/js/board_popups.js
+++ b/js/board_popups.js
@@ -59,12 +59,13 @@ async function closeCard(){
     }
     deactivateFocusLayer({ restoreFocus: true });
     openCardContainer.remove();
-    openCardContainer.classList.add('d-none');
-    openCardContainer.removeAttribute('editing');
 
-    await saveTasksToRemoteStorage();
-    renderCategories(tasks);
-    toggleBoardOverlay('disable');
+    try {
+        await saveTasksToRemoteStorage();
+        renderCategories(tasks);
+    } finally {
+        toggleBoardOverlay('disable');
+    }
 }
 
 

--- a/js/board_state.js
+++ b/js/board_state.js
@@ -115,6 +115,8 @@ async function saveEditedTask(taskId) {
 
     const taskToSaveIndex = findTaskIndex(taskId);
     if (taskToSaveIndex === -1) {
+        await closeCard();
+        showGlobalUserMessage("Could not update this task. Please reload and try again.");
         return;
     }
 
@@ -122,7 +124,7 @@ async function saveEditedTask(taskId) {
     updateTaskImages(taskToSaveIndex);
 
     await saveTasksToRemoteStorage();
-    finalizeEdit();
+    await finalizeEdit();
 }
 
 /**
@@ -132,7 +134,7 @@ async function saveEditedTask(taskId) {
  * @returns {number} Array index or -1.
  */
 function findTaskIndex(taskId) {
-    const index = tasks.findIndex((task) => task.id === taskId);
+    const index = tasks.findIndex((task) => Number(task.id) === Number(taskId));
     if (index === -1) {
         console.error("saveEditedTask: Kein Task gefunden für ID", taskId);
     }
@@ -166,8 +168,8 @@ function updateTaskImages(index) {
 /**
  * Finalizes edit mode and resets staged media.
  */
-function finalizeEdit() {
-    closeCard();
+async function finalizeEdit() {
+    await closeCard();
     showSuccessMessage();
     allImages = [];
 }


### PR DESCRIPTION
## Fix Summary
This PR adds a targeted fix for an overlay lock issue after editing a task without changing values.

## Problem
On board task edit, clicking **OK** without changing fields could leave the gray board overlay active, blocking all further clicks.

## Root Cause
Two failure-prone paths existed:
1. Task lookup during save used strict ID comparison and could miss matches when ID types differed.
2. Overlay cleanup was not guaranteed if an async save path failed.

## Changes
- `js/board_state.js`
  - Use numeric ID comparison in `findTaskIndex` (`Number(task.id) === Number(taskId)`).
  - If task lookup fails, close the card safely and show a user-facing error message.
  - Await async finalize flow (`await finalizeEdit()` and `await closeCard()`).

- `js/board_popups.js`
  - Harden `closeCard()` with `try/finally` so `toggleBoardOverlay('disable')` always runs.

## Result
- Overlay no longer gets stuck after unchanged edit save.
- Board remains clickable and usable.
- Save flow is more robust against async/error edge cases.

## Validation
- `npm run lint` passes.
