### PR TITLE
fix: always disable board overlay on close path

### DIFF
--- a/js/board_popups.js
+++ b/js/board_popups.js
@@ -191,14 +191,17 @@ function hideAddTaskContainer(){
  * @param {string} actionName - Delegated action to trigger on overlay click.
  */
 function toggleBoardOverlay(actionName){
-    let overlay = document.getElementById('boardOverlay')
-    if (overlay.classList.contains('d-none')){
-        overlay.classList.remove('d-none')
-        overlay.dataset.action = actionName;
-    } else if (actionName == 'disable') {
-        overlay.classList.add('d-none')
+    let overlay = document.getElementById('boardOverlay');
+    if (!overlay) return;
+
+    if (actionName == 'disable') {
+        overlay.classList.add('d-none');
         delete overlay.dataset.action;
+        return;
     }
+
+    overlay.classList.remove('d-none');
+    overlay.dataset.action = actionName;
 }
 
 


### PR DESCRIPTION
## Fix Summary
This PR fixes a board interaction lock where the gray overlay could remain active after clicking **OK** in task edit mode (even when no changes were made).

## Root Cause
`toggleBoardOverlay` handled the `disable` case after a visibility check.  
When the overlay already had `d-none`, calling disable could incorrectly re-open the overlay state path.

## Changes
- Updated `toggleBoardOverlay(actionName)` in `js/board_popups.js`:
  - Early-return for `actionName === 'disable'`
  - Always enforce hidden overlay state in disable flow
  - Keep normal enable flow unchanged

## Result
- Overlay is reliably removed on close/save flows.
- Board remains clickable after editing a task and pressing OK without changes.
- No forced page reload is needed.

## Validation
- `npm run lint` passed.
