### PR TITLE
fix: add cache-busting to storage script includes

### DIFF
--- a/addTask.html
+++ b/addTask.html
@@ -28,10 +28,10 @@
   <script src="script.js"></script>
   <script src="js/helper.js"></script>
   <script src="js/config.js"></script>
-  <script src="js/storage_error_policy.js"></script>
-  <script src="js/storage_transport.js"></script>
-  <script src="js/storage_firebase_adapter.js"></script>
-  <script src="js/storage.js"></script>
+  <script src="js/storage_error_policy.js?v=20260226-1"></script>
+  <script src="js/storage_transport.js?v=20260226-1"></script>
+  <script src="js/storage_firebase_adapter.js?v=20260226-1"></script>
+  <script src="js/storage.js?v=20260226-1"></script>
   <script src="js/auth.js"></script>
   <script src="js/addTask_dropdown.js"></script>
   <script src="js/addTask_keyboard.js"></script>

--- a/board.html
+++ b/board.html
@@ -38,10 +38,10 @@
     <script src="./js/addTask.js"></script>
     <script src="./js/addTask_tasks.js"></script>
     <script src="./js/config.js"></script>
-    <script src="./js/storage_error_policy.js"></script>
-    <script src="./js/storage_transport.js"></script>
-    <script src="./js/storage_firebase_adapter.js"></script>
-    <script src="./js/storage.js"></script>
+    <script src="./js/storage_error_policy.js?v=20260226-1"></script>
+    <script src="./js/storage_transport.js?v=20260226-1"></script>
+    <script src="./js/storage_firebase_adapter.js?v=20260226-1"></script>
+    <script src="./js/storage.js?v=20260226-1"></script>
     <script src="./js/auth.js"></script>
     <script src="./js/helper.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/viewerjs/1.11.7/viewer.min.js" integrity="sha512-lZD0JiwhtP4UkFD1mc96NiTZ14L7MjyX5Khk8PMxJszXMLvu7kjq1sp4bb0tcL6MY+/4sIuiUxubOqoueHrW4w==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>

--- a/contacts.html
+++ b/contacts.html
@@ -21,10 +21,10 @@
     <script src="./js/cookiebot-bootstrap.js"></script>
     <script src="script.js"></script>
     <script src="./js/config.js"></script>
-    <script src="./js/storage_error_policy.js"></script>
-    <script src="./js/storage_transport.js"></script>
-    <script src="./js/storage_firebase_adapter.js"></script>
-    <script src="./js/storage.js"></script>
+    <script src="./js/storage_error_policy.js?v=20260226-1"></script>
+    <script src="./js/storage_transport.js?v=20260226-1"></script>
+    <script src="./js/storage_firebase_adapter.js?v=20260226-1"></script>
+    <script src="./js/storage.js?v=20260226-1"></script>
     <script src="./js/auth.js"></script>
     <script src="./js/helper.js"></script>
     <script src="./js/addTask_dropdown.js"></script>

--- a/index.html
+++ b/index.html
@@ -20,10 +20,10 @@
     <script src="./js/cookiebot-bootstrap.js"></script>
     <script src="script.js"></script>
     <script src="./js/config.js"></script>
-    <script src="./js/storage_error_policy.js"></script>
-    <script src="./js/storage_transport.js"></script>
-    <script src="./js/storage_firebase_adapter.js"></script>
-    <script src="./js/storage.js"></script>
+    <script src="./js/storage_error_policy.js?v=20260226-1"></script>
+    <script src="./js/storage_transport.js?v=20260226-1"></script>
+    <script src="./js/storage_firebase_adapter.js?v=20260226-1"></script>
+    <script src="./js/storage.js?v=20260226-1"></script>
     <script src="./js/auth.js"></script>
     <script src="./js/login.js"></script>
 

--- a/signUp.html
+++ b/signUp.html
@@ -16,10 +16,10 @@
   <script src="./js/cookiebot-bootstrap.js"></script>
   <script src="script.js"></script>
   <script src="./js/config.js"></script>
-  <script src="./js/storage_error_policy.js"></script>
-  <script src="./js/storage_transport.js"></script>
-  <script src="./js/storage_firebase_adapter.js"></script>
-  <script src="./js/storage.js"></script>
+  <script src="./js/storage_error_policy.js?v=20260226-1"></script>
+  <script src="./js/storage_transport.js?v=20260226-1"></script>
+  <script src="./js/storage_firebase_adapter.js?v=20260226-1"></script>
+  <script src="./js/storage.js?v=20260226-1"></script>
   <script src="./js/auth.js"></script>
   <script src="./js/signUp.js"></script>
   <script src="./js/helper.js"></script>

--- a/summary.html
+++ b/summary.html
@@ -21,10 +21,10 @@
     <script src="script.js"></script>
     <script src="./assets/templates/html_templates.js"></script>
     <script src="./js/config.js"></script>
-    <script src="./js/storage_error_policy.js"></script>
-    <script src="./js/storage_transport.js"></script>
-    <script src="./js/storage_firebase_adapter.js"></script>
-    <script src="./js/storage.js"></script>
+    <script src="./js/storage_error_policy.js?v=20260226-1"></script>
+    <script src="./js/storage_transport.js?v=20260226-1"></script>
+    <script src="./js/storage_firebase_adapter.js?v=20260226-1"></script>
+    <script src="./js/storage.js?v=20260226-1"></script>
     <script src="./js/auth.js"></script>
     <script src="./js/contacts.js"></script>
     <script src="./js/board.js"></script>


### PR DESCRIPTION
## Summary
This PR adds a production hotfix for `addTask.html` loading failures after the storage modularization rollout.

## Problem
On production, `addTask.html` could render blank and task creation was unavailable.  
The root cause was mixed browser/server cache states during rollout: some clients loaded stale script combinations.

## What this PR changes
- Adds cache-busting query parameters to storage script includes across all relevant pages:
  - `storage_error_policy.js`
  - `storage_transport.js`
  - `storage_firebase_adapter.js`
  - `storage.js`

Updated files:
- `index.html`
- `signUp.html`
- `contacts.html`
- `summary.html`
- `board.html`
- `addTask.html`

## Why
Storage was recently split into multiple modules. During partial cache scenarios, browsers could load incompatible script versions.  
Versioned script URLs force consistent asset retrieval and reduce white-screen risk during deploy transitions.

## Validation
- `npm run lint` passed:
  - template guardrail
  - inline-event guardrail
  - UI token alignment
  - JS page-bundle guardrail

## Impact
- No behavior change to storage APIs or business logic.
- Improves runtime stability in production deploy/cache edge cases.