### PR TITLE
fix: restore delegated create-task action after task persistence

### DIFF
--- a/js/addTask_tasks.js
+++ b/js/addTask_tasks.js
@@ -189,7 +189,7 @@ async function saveTasksToRemoteStorage(){
   const deleteIds = Array.from(pendingTaskDeletes);
 
   if (upsertIds.length === 0 && deleteIds.length === 0) {
-      activateButton('createBtn', 'createTask()');
+      activateButton('createBtn', 'create-task');
       return;
   }
 
@@ -209,7 +209,7 @@ async function saveTasksToRemoteStorage(){
       console.error('Failed to persist task changes:', error);
       showGlobalUserMessage('Could not save task changes. Please try again.');
   } finally {
-      activateButton('createBtn', 'createTask()');
+      activateButton('createBtn', 'create-task');
   }
 }
 


### PR DESCRIPTION
## Summary
This PR fixes a regression where task creation on `addTask.html` could stop working after persistence cycles.

## Root Cause
The create button is wired through delegated events (`data-action="create-task"`).  
In `saveTasksToRemoteStorage()`, the button was re-enabled with the wrong action value (`createTask()`), so delegated click handling could fail.

## Changes
- Updated `js/addTask_tasks.js`:
  - Replaced `activateButton('createBtn', 'createTask()')` with `activateButton('createBtn', 'create-task')` in both reactivation paths:
    - no-op persistence branch
    - `finally` block after save attempt

## Result
- Create button keeps the correct delegated action after storage operations.
- Task creation remains functional and consistent across repeated create/save flows.

## Validation
- `npm run lint` passed:
  - template guardrails
  - inline-event guardrails
  - UI token alignment
  - JS page-bundle guardrail

## Scope
- `js/addTask_tasks.js` only (targeted hotfix)