### PR TITLE
fix: render add task content before footer lookup

### DIFF
--- a/js/addTask.js
+++ b/js/addTask.js
@@ -35,12 +35,15 @@ function callAddTaskFormDomain(methodName, args = [], fallbackValue) {
 
 function renderAddTaskHTML() {
     const container = document.getElementById("addTaskBody");
-    const footerContainer = document.getElementById("addTaskBodyRight");
-    if (!container || !footerContainer) {
+    if (!container) {
         return;
     }
 
     container.innerHTML = renderAddTaskMainContentHTML();
+    const footerContainer = document.getElementById("addTaskBodyRight");
+    if (!footerContainer) {
+        return;
+    }
     footerContainer.innerHTML = renderAddTaskFooterHTML();
 
     registerAddTaskKeyboardAccessibility();


### PR DESCRIPTION
## Summary
This PR fixes the blank `addTask.html` rendering issue caused by render-order logic in the add-task bootstrap flow.

## Root Cause
`renderAddTaskHTML()` looked up `#addTaskBodyRight` before rendering the main add-task template.
On `addTask.html`, that footer element is created by the template itself, so the function returned early and the page stayed empty.

## Changes
- Updated `js/addTask.js`:
  - render main add-task content first
  - then resolve `#addTaskBodyRight`
  - then render footer content

## Result
- `addTask.html` renders reliably again.
- Users can create new tasks as expected.

## Validation
- `npm run lint` passed (all guardrails green).

## Scope
- `js/addTask.js` only.
