### PR TITLE
refactor: split helper utilities into dom sanitize and focus modules

### DIFF
--- a/addTask.html
+++ b/addTask.html
@@ -26,6 +26,9 @@
   <script src="./js/responsive-navigation.js"></script>
   <script src="./js/cookiebot-bootstrap.js"></script>
   <script src="script.js"></script>
+  <script src="js/helper_dom.js"></script>
+  <script src="js/helper_sanitize.js"></script>
+  <script src="js/helper_focus.js"></script>
   <script src="js/helper.js"></script>
   <script src="js/config.js"></script>
   <script src="js/storage_error_policy.js?v=20260226-1"></script>

--- a/board.html
+++ b/board.html
@@ -43,6 +43,9 @@
     <script src="./js/storage_firebase_adapter.js?v=20260226-1"></script>
     <script src="./js/storage.js?v=20260226-1"></script>
     <script src="./js/auth.js"></script>
+    <script src="./js/helper_dom.js"></script>
+    <script src="./js/helper_sanitize.js"></script>
+    <script src="./js/helper_focus.js"></script>
     <script src="./js/helper.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/viewerjs/1.11.7/viewer.min.js" integrity="sha512-lZD0JiwhtP4UkFD1mc96NiTZ14L7MjyX5Khk8PMxJszXMLvu7kjq1sp4bb0tcL6MY+/4sIuiUxubOqoueHrW4w==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 

--- a/contacts.html
+++ b/contacts.html
@@ -26,6 +26,9 @@
     <script src="./js/storage_firebase_adapter.js?v=20260226-1"></script>
     <script src="./js/storage.js?v=20260226-1"></script>
     <script src="./js/auth.js"></script>
+    <script src="./js/helper_dom.js"></script>
+    <script src="./js/helper_sanitize.js"></script>
+    <script src="./js/helper_focus.js"></script>
     <script src="./js/helper.js"></script>
     <script src="./js/addTask_dropdown.js"></script>
     <script src="./js/addTask_keyboard.js"></script>

--- a/js/helper.js
+++ b/js/helper.js
@@ -1,421 +1,184 @@
-/**
- * Clears the inner HTML content of the element with the specified ID.
- *
- * @param {string} id - The ID of the element to clear.
- * @return {string} An empty string.
- */
-function clearDiv(id) {
-	return (document.getElementById(id).innerHTML = "");
-}
-
+"use strict";
 
 /**
- * Prevents the event from propagating further.
+ * Compatibility bootstrap for helper modules.
  *
- * @param {Event} event - The event object to prevent from further propagation.
- * @return {undefined} 
- */
-function doNotClose(event) {
-	event.stopPropagation();
-}
-
-
-/**
- * Sets the attributes of the given element based on the key-value pairs in the attrs object.
+ * Primary implementations now live in:
+ * - js/helper_dom.js
+ * - js/helper_sanitize.js
+ * - js/helper_focus.js
  *
- * @param {Element} el - The element to set attributes for.
- * @param {Object} attrs - An object containing key-value pairs of attributes to set.
- * @return {undefined}
+ * This file only guarantees global API compatibility in mixed cache/deploy states.
  */
-function setAttributes(el, attrs) {
-    for(let key in attrs) {
-      el.setAttribute(key, attrs[key]);
+(function registerHelperCompatibilityLayer() {
+  const hasHelperDom =
+    window.HelperDom && typeof window.HelperDom.setAttributes === "function";
+  const hasHelperSanitize =
+    window.HelperSanitize &&
+    typeof window.HelperSanitize.escapeHtml === "function";
+  const hasHelperFocus =
+    window.HelperFocus &&
+    typeof window.HelperFocus.activateFocusLayer === "function";
+
+  if (!hasHelperDom) {
+    window.clearDiv =
+      typeof window.clearDiv === "function"
+        ? window.clearDiv
+        : (id) => (document.getElementById(id).innerHTML = "");
+    window.doNotClose =
+      typeof window.doNotClose === "function"
+        ? window.doNotClose
+        : (event) => event.stopPropagation();
+    window.setAttributes =
+      typeof window.setAttributes === "function"
+        ? window.setAttributes
+        : (element, attrs) => {
+            for (const key in attrs) {
+              element.setAttribute(key, attrs[key]);
+            }
+          };
+    window.findFreeId =
+      typeof window.findFreeId === "function"
+        ? window.findFreeId
+        : (arrayToCheck) => {
+            for (let i = 0; i < 1000; i++) {
+              let free = true;
+              for (let j = 0; j < arrayToCheck.length; j++) {
+                if (arrayToCheck[j].id == i) {
+                  free = false;
+                }
+              }
+              if (free) return i;
+            }
+            return -1;
+          };
+    window.generateRandomColor =
+      typeof window.generateRandomColor === "function"
+        ? window.generateRandomColor
+        : () => {
+            const colors = [
+              "#76b852",
+              "#ff7043",
+              "#ff3333",
+              "#3399ff",
+              "#ff6666",
+              "#33ccff",
+              "#ff9933",
+              "#66ff66",
+              "#0059ff",
+              "#a64dff",
+            ];
+            return colors[Math.floor(Math.random() * colors.length)];
+          };
+  }
+
+  if (!hasHelperSanitize) {
+    window.escapeHtml =
+      typeof window.escapeHtml === "function"
+        ? window.escapeHtml
+        : (value) => {
+            const normalized = value == null ? "" : String(value);
+            return normalized
+              .replace(/&/g, "&amp;")
+              .replace(/</g, "&lt;")
+              .replace(/>/g, "&gt;")
+              .replace(/"/g, "&quot;")
+              .replace(/'/g, "&#39;");
+          };
+    window.toSafeInteger =
+      typeof window.toSafeInteger === "function"
+        ? window.toSafeInteger
+        : (value, fallback = 0) => {
+            const parsed = Number.parseInt(String(value), 10);
+            return Number.isFinite(parsed) ? parsed : fallback;
+          };
+    window.sanitizeCssColor =
+      typeof window.sanitizeCssColor === "function"
+        ? window.sanitizeCssColor
+        : (value, fallback = "#2a3647") => {
+            const normalized = value == null ? "" : String(value).trim();
+            const isHexColor = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(
+              normalized
+            );
+            return isHexColor ? normalized : fallback;
+          };
+    window.sanitizeMailtoHref =
+      typeof window.sanitizeMailtoHref === "function"
+        ? window.sanitizeMailtoHref
+        : (value) => {
+            const normalized = value == null ? "" : String(value).trim();
+            const singleLineValue = normalized.replace(/[\r\n]+/g, "");
+            if (singleLineValue === "") {
+              return "mailto:";
+            }
+            return `mailto:${encodeURIComponent(singleLineValue)}`;
+          };
+  }
+
+  if (!hasHelperFocus) {
+    window.activateFocusLayer =
+      typeof window.activateFocusLayer === "function"
+        ? window.activateFocusLayer
+        : () => true;
+    window.deactivateFocusLayer =
+      typeof window.deactivateFocusLayer === "function"
+        ? window.deactivateFocusLayer
+        : () => {};
+    window.resolveFocusLayerContainer =
+      typeof window.resolveFocusLayerContainer === "function"
+        ? window.resolveFocusLayerContainer
+        : (containerOrId) =>
+            typeof containerOrId === "string"
+              ? document.getElementById(containerOrId)
+              : containerOrId || null;
+    window.getFocusableElements =
+      typeof window.getFocusableElements === "function"
+        ? window.getFocusableElements
+        : (container) =>
+            container && container.querySelectorAll
+              ? Array.from(
+                  container.querySelectorAll(
+                    "a[href],button:not([disabled]),input:not([disabled]):not([type='hidden']),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex='-1'])"
+                  )
+                )
+              : [];
+    window.isElementVisibleForFocus =
+      typeof window.isElementVisibleForFocus === "function"
+        ? window.isElementVisibleForFocus
+        : (element) =>
+            element instanceof HTMLElement &&
+            element.getClientRects().length > 0 &&
+            getComputedStyle(element).visibility !== "hidden";
+    window.focusElementIfPossible =
+      typeof window.focusElementIfPossible === "function"
+        ? window.focusElementIfPossible
+        : (element) => {
+            if (!(element instanceof HTMLElement) || !element.isConnected) {
+              return false;
+            }
+            try {
+              element.focus();
+              return true;
+            } catch (_error) {
+              return false;
+            }
+          };
+    window.lockOutsideFocusableElements =
+      typeof window.lockOutsideFocusableElements === "function"
+        ? window.lockOutsideFocusableElements
+        : () => [];
+    window.restoreOutsideFocusableElements =
+      typeof window.restoreOutsideFocusableElements === "function"
+        ? window.restoreOutsideFocusableElements
+        : () => {};
+  }
+
+  if (!window.__joinHelperModuleBootstrapInfoLogged) {
+    window.__joinHelperModuleBootstrapInfoLogged = true;
+    if (!hasHelperDom || !hasHelperSanitize || !hasHelperFocus) {
+      console.warn(
+        "Helper module fallback active. Ensure helper_dom.js, helper_sanitize.js and helper_focus.js are loaded before helper.js."
+      );
     }
   }
-
-
-  /**
- * Finds a free ID within the given array by iterating over a range of IDs.
- *
- * @param {Array} arrayToCheck - The array to check for free IDs.
- * @return {number} The first available free ID.
- */
-function findFreeId(arrayToCheck) {
-  for (let i = 0; i < 1000; i++) {
-    let free = true;
-    for (let j = 0; j < arrayToCheck.length; j++) {
-      if (arrayToCheck[j].id == i) {
-        free = false;
-      }
-    }
-    if (free) {
-      return i;
-    }
-  }
-}
-
-
-/**
- * Generates a random color from a predefined list of colors.
- *
- * @function generateRandomColor
- * @returns {string} A randomly selected color.
- */
-function generateRandomColor() {
-  const colors = [
-    "#76b852",
-    "#ff7043",
-    "#ff3333",
-    "#3399ff",
-    "#ff6666",
-    "#33ccff",
-    "#ff9933",
-    "#66ff66",
-    "#0059ff",
-    "#a64dff",
-  ];
-  const randomIndex = Math.floor(Math.random() * colors.length);
-  return colors[randomIndex];
-}
-
-
-/**
- * Escapes text for safe HTML rendering.
- *
- * @param {unknown} value - Raw value to escape.
- * @returns {string} Escaped HTML-safe string.
- */
-function escapeHtml(value) {
-  const normalized = value == null ? "" : String(value);
-  return normalized
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
-
-
-/**
- * Converts values to safe integer IDs for DOM attributes and inline handlers.
- *
- * @param {unknown} value - Candidate ID value.
- * @param {number} [fallback=0] - Fallback when conversion fails.
- * @returns {number} Parsed safe integer.
- */
-function toSafeInteger(value, fallback = 0) {
-  const parsed = Number.parseInt(String(value), 10);
-  return Number.isFinite(parsed) ? parsed : fallback;
-}
-
-
-/**
- * Allows only hex color values for inline style rendering.
- *
- * @param {unknown} value - Candidate CSS color.
- * @param {string} [fallback="#2a3647"] - Fallback color.
- * @returns {string} Safe color string.
- */
-function sanitizeCssColor(value, fallback = "#2a3647") {
-  const normalized = value == null ? "" : String(value).trim();
-  const isHexColor = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(normalized);
-  return isHexColor ? normalized : fallback;
-}
-
-
-/**
- * Builds a safe mailto URL value from user-provided text.
- *
- * @param {unknown} value - Email-like input value.
- * @returns {string} Safe mailto href.
- */
-function sanitizeMailtoHref(value) {
-  const normalized = value == null ? "" : String(value).trim();
-  const singleLineValue = normalized.replace(/[\r\n]+/g, "");
-  if (singleLineValue === "") {
-    return "mailto:";
-  }
-  return `mailto:${encodeURIComponent(singleLineValue)}`;
-}
-
-const FOCUSABLE_SELECTOR = [
-  "a[href]",
-  "button:not([disabled])",
-  "input:not([disabled]):not([type='hidden'])",
-  "select:not([disabled])",
-  "textarea:not([disabled])",
-  "[tabindex]:not([tabindex='-1'])",
-].join(", ");
-
-let activeFocusLayer = null;
-
-/**
- * Activates focus management for dialog-like containers.
- * Traps Tab navigation, supports Esc callback, and restores focus on close.
- *
- * @param {HTMLElement|string} containerOrId - Focus scope container or element id.
- * @param {Object} [options={}] - Focus behavior options.
- * @param {HTMLElement|null} [options.opener] - Element that opened the container.
- * @param {Function|null} [options.onEscape] - Called when Esc is pressed.
- * @param {string|HTMLElement|null} [options.initialFocus] - Initial focus target.
- * @returns {boolean} True if focus layer was activated.
- */
-function activateFocusLayer(containerOrId, options = {}) {
-  const container = resolveFocusLayerContainer(containerOrId);
-  if (!container) {
-    return false;
-  }
-
-  deactivateFocusLayer({ restoreFocus: false });
-
-  const layer = {
-    container,
-    opener: options.opener || document.activeElement,
-    onEscape: typeof options.onEscape === "function" ? options.onEscape : null,
-    initialFocus: options.initialFocus || null,
-    outsideFocusRecords: [],
-    keydownHandler: null,
-    focusinHandler: null,
-  };
-
-  layer.outsideFocusRecords = lockOutsideFocusableElements(container);
-  layer.keydownHandler = (event) => handleFocusLayerKeydown(event, layer);
-  layer.focusinHandler = (event) => handleFocusLayerFocusin(event, layer);
-
-  document.addEventListener("keydown", layer.keydownHandler, true);
-  document.addEventListener("focusin", layer.focusinHandler, true);
-  activeFocusLayer = layer;
-
-  focusLayerInitialTarget(layer);
-  return true;
-}
-
-/**
- * Deactivates active focus management layer.
- *
- * @param {Object} [options={}] - Deactivation options.
- * @param {boolean} [options.restoreFocus=true] - Restore focus to opener.
- * @returns {void}
- */
-function deactivateFocusLayer(options = {}) {
-  if (!activeFocusLayer) {
-    return;
-  }
-
-  const { restoreFocus = true } = options;
-  const layer = activeFocusLayer;
-  activeFocusLayer = null;
-
-  document.removeEventListener("keydown", layer.keydownHandler, true);
-  document.removeEventListener("focusin", layer.focusinHandler, true);
-  restoreOutsideFocusableElements(layer.outsideFocusRecords);
-
-  if (restoreFocus) {
-    focusElementIfPossible(layer.opener);
-  }
-}
-
-/**
- * Resolves container references for focus layer activation.
- *
- * @param {HTMLElement|string} containerOrId - Container reference.
- * @returns {HTMLElement|null} Resolved container element.
- */
-function resolveFocusLayerContainer(containerOrId) {
-  if (!containerOrId) {
-    return null;
-  }
-  if (typeof containerOrId === "string") {
-    return document.getElementById(containerOrId);
-  }
-  if (containerOrId instanceof HTMLElement) {
-    return containerOrId;
-  }
-  return null;
-}
-
-/**
- * Handles keyboard behavior for the active focus layer.
- *
- * @param {KeyboardEvent} event - Keyboard event.
- * @param {Object} layer - Active focus layer data.
- * @returns {void}
- */
-function handleFocusLayerKeydown(event, layer) {
-  if (activeFocusLayer !== layer || !layer.container.isConnected) {
-    return;
-  }
-
-  if (event.key === "Escape" && layer.onEscape) {
-    event.preventDefault();
-    event.stopPropagation();
-    layer.onEscape();
-    return;
-  }
-
-  if (event.key !== "Tab") {
-    return;
-  }
-
-  const focusableElements = getFocusableElements(layer.container);
-  if (focusableElements.length === 0) {
-    event.preventDefault();
-    focusElementIfPossible(layer.container);
-    return;
-  }
-
-  const first = focusableElements[0];
-  const last = focusableElements[focusableElements.length - 1];
-  const activeElement = document.activeElement;
-
-  if (event.shiftKey) {
-    if (activeElement === first || !layer.container.contains(activeElement)) {
-      event.preventDefault();
-      focusElementIfPossible(last);
-    }
-    return;
-  }
-
-  if (activeElement === last || !layer.container.contains(activeElement)) {
-    event.preventDefault();
-    focusElementIfPossible(first);
-  }
-}
-
-/**
- * Ensures focus cannot leave active layer container.
- *
- * @param {FocusEvent} event - Focus event.
- * @param {Object} layer - Active focus layer data.
- * @returns {void}
- */
-function handleFocusLayerFocusin(event, layer) {
-  if (activeFocusLayer !== layer || !layer.container.isConnected) {
-    return;
-  }
-
-  if (layer.container.contains(event.target)) {
-    return;
-  }
-
-  const fallbackTarget = getFocusableElements(layer.container)[0] || layer.container;
-  focusElementIfPossible(fallbackTarget);
-}
-
-/**
- * Applies initial focus when a layer opens.
- *
- * @param {Object} layer - Active focus layer data.
- * @returns {void}
- */
-function focusLayerInitialTarget(layer) {
-  const { container, initialFocus } = layer;
-  let initialTarget = null;
-
-  if (typeof initialFocus === "string" && initialFocus.trim() !== "") {
-    initialTarget = container.querySelector(initialFocus);
-  } else if (initialFocus instanceof HTMLElement) {
-    initialTarget = initialFocus;
-  }
-
-  if (!initialTarget) {
-    initialTarget = getFocusableElements(container)[0] || container;
-  }
-
-  if (!initialTarget.hasAttribute("tabindex") && initialTarget === container) {
-    initialTarget.setAttribute("tabindex", "-1");
-  }
-
-  focusElementIfPossible(initialTarget);
-}
-
-/**
- * Returns focusable descendants inside a given container.
- *
- * @param {HTMLElement} container - Scope container.
- * @returns {HTMLElement[]} Focusable elements.
- */
-function getFocusableElements(container) {
-  return Array.from(container.querySelectorAll(FOCUSABLE_SELECTOR)).filter(
-    (element) =>
-      element instanceof HTMLElement &&
-      !element.hasAttribute("disabled") &&
-      isElementVisibleForFocus(element)
-  );
-}
-
-/**
- * Checks whether an element is visible enough to receive focus.
- *
- * @param {HTMLElement} element - Candidate element.
- * @returns {boolean} True when visible.
- */
-function isElementVisibleForFocus(element) {
-  return (
-    element.getClientRects().length > 0 &&
-    getComputedStyle(element).visibility !== "hidden"
-  );
-}
-
-/**
- * Focuses an element when possible.
- *
- * @param {HTMLElement|null} element - Focus target.
- * @returns {boolean} True when focus call was attempted.
- */
-function focusElementIfPossible(element) {
-  if (!(element instanceof HTMLElement) || !element.isConnected) {
-    return false;
-  }
-  try {
-    element.focus();
-    return true;
-  } catch (error) {
-    return false;
-  }
-}
-
-/**
- * Removes all outside elements from tab-order while overlay is active.
- *
- * @param {HTMLElement} container - Active focus layer container.
- * @returns {Array<{element: HTMLElement, tabindex: string|null}>} Stored tabindex records.
- */
-function lockOutsideFocusableElements(container) {
-  const allFocusable = Array.from(document.querySelectorAll(FOCUSABLE_SELECTOR));
-  const records = [];
-
-  allFocusable.forEach((element) => {
-    if (!(element instanceof HTMLElement)) {
-      return;
-    }
-    if (container.contains(element)) {
-      return;
-    }
-    records.push({ element, tabindex: element.getAttribute("tabindex") });
-    element.setAttribute("tabindex", "-1");
-  });
-
-  return records;
-}
-
-/**
- * Restores tabindex values for elements changed by lockOutsideFocusableElements.
- *
- * @param {Array<{element: HTMLElement, tabindex: string|null}>} records - Stored tabindex records.
- * @returns {void}
- */
-function restoreOutsideFocusableElements(records) {
-  records.forEach(({ element, tabindex }) => {
-    if (!(element instanceof HTMLElement) || !element.isConnected) {
-      return;
-    }
-
-    if (tabindex === null) {
-      element.removeAttribute("tabindex");
-      return;
-    }
-
-    element.setAttribute("tabindex", tabindex);
-  });
-}
+})();

--- a/js/helper_dom.js
+++ b/js/helper_dom.js
@@ -1,0 +1,63 @@
+"use strict";
+
+(function registerHelperDomModule() {
+  const hdClearDiv = (id) => {
+    return (document.getElementById(id).innerHTML = "");
+  };
+
+  const hdDoNotClose = (event) => {
+    event.stopPropagation();
+  };
+
+  const hdSetAttributes = (element, attrs) => {
+    for (const key in attrs) {
+      element.setAttribute(key, attrs[key]);
+    }
+  };
+
+  const hdFindFreeId = (arrayToCheck) => {
+    for (let i = 0; i < 1000; i++) {
+      let free = true;
+      for (let j = 0; j < arrayToCheck.length; j++) {
+        if (arrayToCheck[j].id == i) {
+          free = false;
+        }
+      }
+      if (free) {
+        return i;
+      }
+    }
+    return -1;
+  };
+
+  const hdGenerateRandomColor = () => {
+    const colors = [
+      "#76b852",
+      "#ff7043",
+      "#ff3333",
+      "#3399ff",
+      "#ff6666",
+      "#33ccff",
+      "#ff9933",
+      "#66ff66",
+      "#0059ff",
+      "#a64dff",
+    ];
+    const randomIndex = Math.floor(Math.random() * colors.length);
+    return colors[randomIndex];
+  };
+
+  window.HelperDom = Object.freeze({
+    clearDiv: hdClearDiv,
+    doNotClose: hdDoNotClose,
+    setAttributes: hdSetAttributes,
+    findFreeId: hdFindFreeId,
+    generateRandomColor: hdGenerateRandomColor,
+  });
+
+  window.clearDiv = hdClearDiv;
+  window.doNotClose = hdDoNotClose;
+  window.setAttributes = hdSetAttributes;
+  window.findFreeId = hdFindFreeId;
+  window.generateRandomColor = hdGenerateRandomColor;
+})();

--- a/js/helper_focus.js
+++ b/js/helper_focus.js
@@ -1,0 +1,231 @@
+"use strict";
+
+(function registerHelperFocusModule() {
+  const HF_FOCUSABLE_SELECTOR = [
+    "a[href]",
+    "button:not([disabled])",
+    "input:not([disabled]):not([type='hidden'])",
+    "select:not([disabled])",
+    "textarea:not([disabled])",
+    "[tabindex]:not([tabindex='-1'])",
+  ].join(", ");
+
+  let hfActiveFocusLayer = null;
+
+  const hfResolveFocusLayerContainer = (containerOrId) => {
+    if (!containerOrId) {
+      return null;
+    }
+    if (typeof containerOrId === "string") {
+      return document.getElementById(containerOrId);
+    }
+    if (containerOrId instanceof HTMLElement) {
+      return containerOrId;
+    }
+    return null;
+  };
+
+  const hfIsElementVisibleForFocus = (element) => {
+    return (
+      element.getClientRects().length > 0 &&
+      getComputedStyle(element).visibility !== "hidden"
+    );
+  };
+
+  const hfGetFocusableElements = (container) => {
+    return Array.from(container.querySelectorAll(HF_FOCUSABLE_SELECTOR)).filter(
+      (element) =>
+        element instanceof HTMLElement &&
+        !element.hasAttribute("disabled") &&
+        hfIsElementVisibleForFocus(element)
+    );
+  };
+
+  const hfFocusElementIfPossible = (element) => {
+    if (!(element instanceof HTMLElement) || !element.isConnected) {
+      return false;
+    }
+    try {
+      element.focus();
+      return true;
+    } catch (_error) {
+      return false;
+    }
+  };
+
+  const hfLockOutsideFocusableElements = (container) => {
+    const allFocusable = Array.from(
+      document.querySelectorAll(HF_FOCUSABLE_SELECTOR)
+    );
+    const records = [];
+
+    allFocusable.forEach((element) => {
+      if (!(element instanceof HTMLElement)) {
+        return;
+      }
+      if (container.contains(element)) {
+        return;
+      }
+      records.push({ element, tabindex: element.getAttribute("tabindex") });
+      element.setAttribute("tabindex", "-1");
+    });
+
+    return records;
+  };
+
+  const hfRestoreOutsideFocusableElements = (records) => {
+    records.forEach(({ element, tabindex }) => {
+      if (!(element instanceof HTMLElement) || !element.isConnected) {
+        return;
+      }
+      if (tabindex === null) {
+        element.removeAttribute("tabindex");
+        return;
+      }
+      element.setAttribute("tabindex", tabindex);
+    });
+  };
+
+  const hfHandleFocusLayerKeydown = (event, layer) => {
+    if (hfActiveFocusLayer !== layer || !layer.container.isConnected) {
+      return;
+    }
+
+    if (event.key === "Escape" && layer.onEscape) {
+      event.preventDefault();
+      event.stopPropagation();
+      layer.onEscape();
+      return;
+    }
+
+    if (event.key !== "Tab") {
+      return;
+    }
+
+    const focusableElements = hfGetFocusableElements(layer.container);
+    if (focusableElements.length === 0) {
+      event.preventDefault();
+      hfFocusElementIfPossible(layer.container);
+      return;
+    }
+
+    const first = focusableElements[0];
+    const last = focusableElements[focusableElements.length - 1];
+    const activeElement = document.activeElement;
+
+    if (event.shiftKey) {
+      if (activeElement === first || !layer.container.contains(activeElement)) {
+        event.preventDefault();
+        hfFocusElementIfPossible(last);
+      }
+      return;
+    }
+
+    if (activeElement === last || !layer.container.contains(activeElement)) {
+      event.preventDefault();
+      hfFocusElementIfPossible(first);
+    }
+  };
+
+  const hfHandleFocusLayerFocusin = (event, layer) => {
+    if (hfActiveFocusLayer !== layer || !layer.container.isConnected) {
+      return;
+    }
+    if (layer.container.contains(event.target)) {
+      return;
+    }
+
+    const fallbackTarget = hfGetFocusableElements(layer.container)[0] || layer.container;
+    hfFocusElementIfPossible(fallbackTarget);
+  };
+
+  const hfFocusLayerInitialTarget = (layer) => {
+    const { container, initialFocus } = layer;
+    let initialTarget = null;
+
+    if (typeof initialFocus === "string" && initialFocus.trim() !== "") {
+      initialTarget = container.querySelector(initialFocus);
+    } else if (initialFocus instanceof HTMLElement) {
+      initialTarget = initialFocus;
+    }
+
+    if (!initialTarget) {
+      initialTarget = hfGetFocusableElements(container)[0] || container;
+    }
+
+    if (!initialTarget.hasAttribute("tabindex") && initialTarget === container) {
+      initialTarget.setAttribute("tabindex", "-1");
+    }
+
+    hfFocusElementIfPossible(initialTarget);
+  };
+
+  const hfDeactivateFocusLayer = (options = {}) => {
+    if (!hfActiveFocusLayer) {
+      return;
+    }
+
+    const { restoreFocus = true } = options;
+    const layer = hfActiveFocusLayer;
+    hfActiveFocusLayer = null;
+
+    document.removeEventListener("keydown", layer.keydownHandler, true);
+    document.removeEventListener("focusin", layer.focusinHandler, true);
+    hfRestoreOutsideFocusableElements(layer.outsideFocusRecords);
+
+    if (restoreFocus) {
+      hfFocusElementIfPossible(layer.opener);
+    }
+  };
+
+  const hfActivateFocusLayer = (containerOrId, options = {}) => {
+    const container = hfResolveFocusLayerContainer(containerOrId);
+    if (!container) {
+      return false;
+    }
+
+    hfDeactivateFocusLayer({ restoreFocus: false });
+
+    const layer = {
+      container,
+      opener: options.opener || document.activeElement,
+      onEscape: typeof options.onEscape === "function" ? options.onEscape : null,
+      initialFocus: options.initialFocus || null,
+      outsideFocusRecords: [],
+      keydownHandler: null,
+      focusinHandler: null,
+    };
+
+    layer.outsideFocusRecords = hfLockOutsideFocusableElements(container);
+    layer.keydownHandler = (event) => hfHandleFocusLayerKeydown(event, layer);
+    layer.focusinHandler = (event) => hfHandleFocusLayerFocusin(event, layer);
+
+    document.addEventListener("keydown", layer.keydownHandler, true);
+    document.addEventListener("focusin", layer.focusinHandler, true);
+    hfActiveFocusLayer = layer;
+
+    hfFocusLayerInitialTarget(layer);
+    return true;
+  };
+
+  window.HelperFocus = Object.freeze({
+    FOCUSABLE_SELECTOR: HF_FOCUSABLE_SELECTOR,
+    activateFocusLayer: hfActivateFocusLayer,
+    deactivateFocusLayer: hfDeactivateFocusLayer,
+    resolveFocusLayerContainer: hfResolveFocusLayerContainer,
+    getFocusableElements: hfGetFocusableElements,
+    isElementVisibleForFocus: hfIsElementVisibleForFocus,
+    focusElementIfPossible: hfFocusElementIfPossible,
+    lockOutsideFocusableElements: hfLockOutsideFocusableElements,
+    restoreOutsideFocusableElements: hfRestoreOutsideFocusableElements,
+  });
+
+  window.activateFocusLayer = hfActivateFocusLayer;
+  window.deactivateFocusLayer = hfDeactivateFocusLayer;
+  window.resolveFocusLayerContainer = hfResolveFocusLayerContainer;
+  window.getFocusableElements = hfGetFocusableElements;
+  window.isElementVisibleForFocus = hfIsElementVisibleForFocus;
+  window.focusElementIfPossible = hfFocusElementIfPossible;
+  window.lockOutsideFocusableElements = hfLockOutsideFocusableElements;
+  window.restoreOutsideFocusableElements = hfRestoreOutsideFocusableElements;
+})();

--- a/js/helper_sanitize.js
+++ b/js/helper_sanitize.js
@@ -1,0 +1,45 @@
+"use strict";
+
+(function registerHelperSanitizeModule() {
+  const hsEscapeHtml = (value) => {
+    const normalized = value == null ? "" : String(value);
+    return normalized
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  };
+
+  const hsToSafeInteger = (value, fallback = 0) => {
+    const parsed = Number.parseInt(String(value), 10);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  };
+
+  const hsSanitizeCssColor = (value, fallback = "#2a3647") => {
+    const normalized = value == null ? "" : String(value).trim();
+    const isHexColor = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(normalized);
+    return isHexColor ? normalized : fallback;
+  };
+
+  const hsSanitizeMailtoHref = (value) => {
+    const normalized = value == null ? "" : String(value).trim();
+    const singleLineValue = normalized.replace(/[\r\n]+/g, "");
+    if (singleLineValue === "") {
+      return "mailto:";
+    }
+    return `mailto:${encodeURIComponent(singleLineValue)}`;
+  };
+
+  window.HelperSanitize = Object.freeze({
+    escapeHtml: hsEscapeHtml,
+    toSafeInteger: hsToSafeInteger,
+    sanitizeCssColor: hsSanitizeCssColor,
+    sanitizeMailtoHref: hsSanitizeMailtoHref,
+  });
+
+  window.escapeHtml = hsEscapeHtml;
+  window.toSafeInteger = hsToSafeInteger;
+  window.sanitizeCssColor = hsSanitizeCssColor;
+  window.sanitizeMailtoHref = hsSanitizeMailtoHref;
+})();

--- a/signUp.html
+++ b/signUp.html
@@ -21,6 +21,9 @@
   <script src="./js/storage_firebase_adapter.js?v=20260226-1"></script>
   <script src="./js/storage.js?v=20260226-1"></script>
   <script src="./js/auth.js"></script>
+  <script src="./js/helper_dom.js"></script>
+  <script src="./js/helper_sanitize.js"></script>
+  <script src="./js/helper_focus.js"></script>
   <script src="./js/signUp.js"></script>
   <script src="./js/helper.js"></script>
   <title>Join - Sign Up</title>


### PR DESCRIPTION
PR text (#83)
Summary
This PR resolves #83 by splitting [helper.js](https://file+.vscode-resource.vscode-cdn.net/Users/sebastianschult/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#) into focused utility modules while preserving global API compatibility for existing non-module pages.

What changed
Extracted helper concerns into dedicated files:
[helper_dom.js](https://file+.vscode-resource.vscode-cdn.net/Users/sebastianschult/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#)
[helper_sanitize.js](https://file+.vscode-resource.vscode-cdn.net/Users/sebastianschult/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#)
[helper_focus.js](https://file+.vscode-resource.vscode-cdn.net/Users/sebastianschult/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#)
Refactored [helper.js](https://file+.vscode-resource.vscode-cdn.net/Users/sebastianschult/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#) into a compatibility bootstrap layer:
keeps existing global helper contracts available
provides fallback behavior for mixed cache/deploy states
Updated script load order so focused helper modules load before [helper.js](https://file+.vscode-resource.vscode-cdn.net/Users/sebastianschult/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#):
[addTask.html](https://file+.vscode-resource.vscode-cdn.net/Users/sebastianschult/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#)
[board.html](https://file+.vscode-resource.vscode-cdn.net/Users/sebastianschult/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#)
[contacts.html](https://file+.vscode-resource.vscode-cdn.net/Users/sebastianschult/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#)
[signUp.html](https://file+.vscode-resource.vscode-cdn.net/Users/sebastianschult/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#)
Why
[helper.js](https://file+.vscode-resource.vscode-cdn.net/Users/sebastianschult/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#) previously mixed unrelated concerns (DOM utils, sanitization, focus/accessibility) in one large file, increasing coupling and change risk.
This split improves maintainability and reduces blast radius while keeping runtime behavior stable.

Validation
npm run lint passed:
template guardrail
inline-event guardrail
UI token alignment
JS page-bundle guardrail
Scope
Helper modularization only.
No intentional behavior changes in feature flows.