### PR TITLE
[P2][Chore]: Add file-size guardrail for JS and CSS in CI

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -49,6 +49,12 @@ jobs:
           set -euo pipefail
           npm run lint:ui-tokens
 
+      - name: Guardrail check for JS/CSS file-size thresholds
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run lint:file-size
+
       - name: Guardrail check for undefined/redeclared JS references across page bundles
         shell: bash
         run: |

--- a/ENGINEERING_STANDARDS.md
+++ b/ENGINEERING_STANDARDS.md
@@ -93,6 +93,7 @@ Every refactor PR should include:
 2. Risk notes (possible regressions and impacted flows/pages).
 3. Validation evidence:
    - `npm run lint`
+   - `npm run lint:file-size`
    - manual smoke checks for affected user journeys
 4. Backward compatibility notes for mixed deploy/cache states when runtime code is touched.
 5. Follow-up tickets for deferred cleanup.

--- a/FILE_SIZE_GUARDRAILS.md
+++ b/FILE_SIZE_GUARDRAILS.md
@@ -1,0 +1,36 @@
+# File-Size Guardrails
+
+This repository enforces line-count guardrails for JavaScript and CSS files in PR CI.
+
+Guardrail script:
+
+- `scripts/check_file_size_guardrail.cjs`
+
+Local command:
+
+```bash
+npm run lint:file-size
+```
+
+## Thresholds
+
+| File type | Warning threshold | Hard-fail threshold |
+| --- | --- | --- |
+| JavaScript (`.js`) | > 300 lines | > 400 lines |
+| CSS (`.css`) | > 800 lines | > 1000 lines |
+
+Behavior:
+
+- files above warning threshold are reported as warnings
+- files above hard-fail threshold fail CI
+
+## Current Exceptions
+
+These are explicit temporary exceptions with higher hard-fail caps.
+
+| File | Exception hard-fail cap | Reason |
+| --- | --- | --- |
+| `assets/templates/html_templates.js` | 650 lines | Legacy shared template bundle pending decomposition into focused template modules. |
+| `assets/css/contacts.css` | 1200 lines | Legacy contacts stylesheet pending modular split by component/responsibility. |
+
+When a refactor reduces one of these files below default limits, remove the exception.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Then open `http://127.0.0.1:4173/index.html`.
 
 ```bash
 npm run lint
+npm run lint:file-size
 npm run a11y:audit
 npm run a11y:ci
 npm run a11y:report
@@ -41,6 +42,7 @@ npm run a11y:report
 - Deployment pipeline: [DEPLOYMENT.md](./DEPLOYMENT.md)
 - GitHub issue/PR/project/deploy automation: [GITHUB_AUTOMATION.md](./GITHUB_AUTOMATION.md)
 - Accessibility checks: [ACCESSIBILITY_CHECKS.md](./ACCESSIBILITY_CHECKS.md)
+- File-size guardrails: [FILE_SIZE_GUARDRAILS.md](./FILE_SIZE_GUARDRAILS.md)
 - UI tokens and breakpoints: [UI_TOKENS.md](./UI_TOKENS.md)
 - Secure rendering / XSS rules: [SECURITY_RENDERING.md](./SECURITY_RENDERING.md)
 - Refactor baseline and roadmap: [REFACTOR_RESEARCH.md](./REFACTOR_RESEARCH.md)

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "private": true,
   "scripts": {
     "lint:js": "node scripts/lint_page_bundles.cjs",
+    "lint:file-size": "node scripts/check_file_size_guardrail.cjs",
     "lint:templates": "node scripts/check_duplicate_template_attributes.cjs",
     "lint:inline-events": "node scripts/check_inline_event_handlers.cjs",
     "lint:ui-tokens": "node scripts/check_ui_tokens_alignment.cjs",
-    "lint": "npm run lint:templates && npm run lint:inline-events && npm run lint:ui-tokens && npm run lint:js",
+    "lint": "npm run lint:templates && npm run lint:inline-events && npm run lint:ui-tokens && npm run lint:file-size && npm run lint:js",
     "a11y:ci": "npx --yes @lhci/cli autorun --config=./lighthouserc.cjs",
     "a11y:report": "node scripts/summarize_lighthouse_accessibility.cjs",
     "a11y:audit": "node scripts/check_accessibility_baseline.cjs"

--- a/scripts/check_file_size_guardrail.cjs
+++ b/scripts/check_file_size_guardrail.cjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const RULES = Object.freeze([
+  {
+    id: "js",
+    label: "JavaScript",
+    extensions: new Set([".js"]),
+    warningLines: 300,
+    errorLines: 400,
+    include: [
+      { type: "dir", value: "js" },
+      { type: "dir", value: "assets/templates" },
+      { type: "file", value: "script.js" },
+    ],
+    exceptions: Object.freeze({
+      "assets/templates/html_templates.js": Object.freeze({
+        maxLines: 650,
+        reason:
+          "Legacy shared template bundle; scheduled for decomposition into focused template modules.",
+      }),
+    }),
+  },
+  {
+    id: "css",
+    label: "CSS",
+    extensions: new Set([".css"]),
+    warningLines: 800,
+    errorLines: 1000,
+    include: [
+      { type: "dir", value: "assets/css" },
+      { type: "file", value: "style.css" },
+    ],
+    exceptions: Object.freeze({
+      "assets/css/contacts.css": Object.freeze({
+        maxLines: 1200,
+        reason:
+          "Legacy contacts stylesheet; scheduled for modular CSS split by component/responsibility.",
+      }),
+    }),
+  },
+]);
+
+const findings = {
+  warnings: [],
+  errors: [],
+};
+
+for (const rule of RULES) {
+  const files = collectRuleFiles(rule);
+  for (const filePath of files) {
+    const source = fs.readFileSync(filePath, "utf8");
+    const lineCount = source.split(/\r?\n/).length;
+    const exception = rule.exceptions[filePath];
+    const maxLines = exception ? exception.maxLines : rule.errorLines;
+
+    if (lineCount > maxLines) {
+      findings.errors.push({
+        rule,
+        filePath,
+        lineCount,
+        maxLines,
+        exception,
+      });
+      continue;
+    }
+
+    if (lineCount > rule.warningLines) {
+      findings.warnings.push({
+        rule,
+        filePath,
+        lineCount,
+        maxLines,
+        exception,
+      });
+    }
+  }
+}
+
+if (findings.warnings.length > 0) {
+  console.warn(
+    `File-size guardrail warnings (${findings.warnings.length}) - consider splitting large files:`
+  );
+  for (const warning of findings.warnings) {
+    console.warn(
+      formatFinding("warning", warning, {
+        label: `>${warning.rule.warningLines}`,
+      })
+    );
+  }
+}
+
+if (findings.errors.length > 0) {
+  console.error(
+    `File-size guardrail failed: ${findings.errors.length} file(s) exceed configured hard limits.`
+  );
+  for (const error of findings.errors) {
+    console.error(
+      formatFinding("error", error, {
+        label: `>${error.maxLines}`,
+      })
+    );
+  }
+  process.exit(1);
+}
+
+if (findings.warnings.length > 0) {
+  console.log("File-size guardrail passed with warnings.");
+} else {
+  console.log("File-size guardrail passed.");
+}
+
+function collectRuleFiles(rule) {
+  const result = new Set();
+
+  for (const target of rule.include) {
+    if (target.type === "file") {
+      const absolutePath = path.resolve(process.cwd(), target.value);
+      if (!fs.existsSync(absolutePath)) continue;
+      const relativePath = normalizePath(path.relative(process.cwd(), absolutePath));
+      if (rule.extensions.has(path.extname(relativePath))) {
+        result.add(relativePath);
+      }
+      continue;
+    }
+
+    if (target.type === "dir") {
+      const absoluteDir = path.resolve(process.cwd(), target.value);
+      collectDirectoryFiles(absoluteDir, rule.extensions, result);
+    }
+  }
+
+  return Array.from(result).sort();
+}
+
+function collectDirectoryFiles(dirPath, extensions, result) {
+  if (!fs.existsSync(dirPath)) return;
+
+  const entries = fs.readdirSync(dirPath, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      collectDirectoryFiles(fullPath, extensions, result);
+      continue;
+    }
+
+    if (!entry.isFile()) continue;
+
+    const relativePath = normalizePath(path.relative(process.cwd(), fullPath));
+    if (!extensions.has(path.extname(relativePath))) continue;
+    result.add(relativePath);
+  }
+}
+
+function formatFinding(level, finding, threshold) {
+  const parts = [
+    `[${finding.rule.id.toUpperCase()}][${level}] ${finding.filePath}: ${finding.lineCount} lines`,
+    `(warn>${finding.rule.warningLines}, hard>${finding.maxLines})`,
+  ];
+
+  if (finding.exception) {
+    parts.push(`exception: ${finding.exception.reason}`);
+  }
+
+  if (threshold && threshold.label) {
+    parts.push(`trigger: ${threshold.label}`);
+  }
+
+  return `- ${parts.join(" ")}`;
+}
+
+function normalizePath(filePath) {
+  return filePath.split(path.sep).join("/");
+}


### PR DESCRIPTION
## Summary
- add a CI guardrail script for JS and CSS line-count thresholds
- report warnings for large files and fail on hard-limit violations
- integrate guardrail into PR tests workflow and local lint command
- document thresholds, temporary exceptions, and local usage

## Changes
- add scripts/check_file_size_guardrail.cjs
- add npm script lint:file-size and include it in lint
- add PR workflow step: Guardrail check for JS/CSS file-size thresholds
- add FILE_SIZE_GUARDRAILS.md and link it from README
- extend engineering standards checklist with lint:file-size

## Thresholds
- JavaScript: warning above 300 lines, hard-fail above 400 lines
- CSS: warning above 800 lines, hard-fail above 1000 lines

## Exceptions
- assets/templates/html_templates.js hard cap 650 lines
- assets/css/contacts.css hard cap 1200 lines

## Validation
- npm run lint:file-size
- npm run lint

Closes #84