### PR TITLE
chore: add jsdoc coverage guardrail and baseline

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -55,6 +55,14 @@ jobs:
           set -euo pipefail
           npm run lint:file-size
 
+      - name: Guardrail check for JSDoc coverage baseline (warning mode)
+        shell: bash
+        env:
+          JSDOC_GUARDRAIL_MODE: warn
+        run: |
+          set -euo pipefail
+          npm run lint:jsdoc
+
       - name: Guardrail check for undefined/redeclared JS references across page bundles
         shell: bash
         run: |

--- a/ENGINEERING_STANDARDS.md
+++ b/ENGINEERING_STANDARDS.md
@@ -93,6 +93,7 @@ Every refactor PR should include:
 2. Risk notes (possible regressions and impacted flows/pages).
 3. Validation evidence:
    - `npm run lint`
+   - `npm run lint:jsdoc`
    - `npm run lint:file-size`
    - manual smoke checks for affected user journeys
 4. Backward compatibility notes for mixed deploy/cache states when runtime code is touched.

--- a/JSDOC_GUARDRAILS.md
+++ b/JSDOC_GUARDRAILS.md
@@ -1,0 +1,67 @@
+# JSDoc Guardrails
+
+This document defines how JSDoc coverage is measured and enforced in CI.
+
+## Scope
+
+The guardrail script scans runtime JavaScript files:
+
+- `script.js`
+- all `js/**/*.js` files except:
+  - `js/config.js`
+  - `js/config.example.js`
+
+Current detection scope is top-level function declarations only (global/page runtime functions).
+
+## Commands
+
+Run coverage check locally:
+
+```bash
+npm run lint:jsdoc
+```
+
+Regenerate baseline after intentional documentation improvements:
+
+```bash
+npm run lint:jsdoc:update-baseline
+```
+
+## Modes
+
+The script supports two modes via `JSDOC_GUARDRAIL_MODE`:
+
+- `warn` (default):
+  - prints missing JSDoc per file/function
+  - exits with success
+- `fail-on-regression`:
+  - compares current report against baseline in `scripts/jsdoc_guardrail_baseline.json`
+  - fails if documentation regresses
+
+Example:
+
+```bash
+JSDOC_GUARDRAIL_MODE=fail-on-regression npm run lint:jsdoc
+```
+
+## Regression Policy
+
+In `fail-on-regression` mode, CI fails when one of these happens:
+
+- overall missing declaration count increases
+- overall coverage percent decreases
+- a tracked file has more missing declarations than baseline
+- a newly scanned file starts with missing declarations
+
+## CI Integration
+
+PR CI runs the guardrail in warning mode first:
+
+- workflow: `.github/workflows/pr-tests.yml`
+- step: `Guardrail check for JSDoc coverage baseline (warning mode)`
+
+The policy is intentionally staged:
+
+1. warning mode while coverage debt is still being reduced
+2. switch to `fail-on-regression` after baseline stabilization
+

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Then open `http://127.0.0.1:4173/index.html`.
 
 ```bash
 npm run lint
+npm run lint:jsdoc
 npm run lint:file-size
 npm run a11y:audit
 npm run a11y:ci
@@ -43,6 +44,7 @@ npm run a11y:report
 - GitHub issue/PR/project/deploy automation: [GITHUB_AUTOMATION.md](./GITHUB_AUTOMATION.md)
 - Accessibility checks: [ACCESSIBILITY_CHECKS.md](./ACCESSIBILITY_CHECKS.md)
 - File-size guardrails: [FILE_SIZE_GUARDRAILS.md](./FILE_SIZE_GUARDRAILS.md)
+- JSDoc guardrails: [JSDOC_GUARDRAILS.md](./JSDOC_GUARDRAILS.md)
 - UI tokens and breakpoints: [UI_TOKENS.md](./UI_TOKENS.md)
 - Secure rendering / XSS rules: [SECURITY_RENDERING.md](./SECURITY_RENDERING.md)
 - Refactor baseline and roadmap: [REFACTOR_RESEARCH.md](./REFACTOR_RESEARCH.md)

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "private": true,
   "scripts": {
     "lint:js": "node scripts/lint_page_bundles.cjs",
+    "lint:jsdoc": "node scripts/check_jsdoc_coverage.cjs",
+    "lint:jsdoc:update-baseline": "node scripts/check_jsdoc_coverage.cjs --update-baseline",
     "lint:file-size": "node scripts/check_file_size_guardrail.cjs",
     "lint:templates": "node scripts/check_duplicate_template_attributes.cjs",
     "lint:inline-events": "node scripts/check_inline_event_handlers.cjs",
     "lint:ui-tokens": "node scripts/check_ui_tokens_alignment.cjs",
-    "lint": "npm run lint:templates && npm run lint:inline-events && npm run lint:ui-tokens && npm run lint:file-size && npm run lint:js",
+    "lint": "npm run lint:templates && npm run lint:inline-events && npm run lint:ui-tokens && npm run lint:file-size && npm run lint:jsdoc && npm run lint:js",
     "a11y:ci": "npx --yes @lhci/cli autorun --config=./lighthouserc.cjs",
     "a11y:report": "node scripts/summarize_lighthouse_accessibility.cjs",
     "a11y:audit": "node scripts/check_accessibility_baseline.cjs"

--- a/scripts/check_jsdoc_coverage.cjs
+++ b/scripts/check_jsdoc_coverage.cjs
@@ -1,0 +1,353 @@
+#!/usr/bin/env node
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const MODE_VALUES = new Set(["warn", "fail-on-regression"]);
+const DEFAULT_MODE = "warn";
+const BASELINE_FILE_PATH = normalizePath(
+  process.env.JSDOC_GUARDRAIL_BASELINE || "scripts/jsdoc_guardrail_baseline.json"
+);
+const UPDATE_BASELINE = process.argv.includes("--update-baseline");
+
+const RUNTIME_TARGETS = Object.freeze([
+  { type: "file", value: "script.js" },
+  { type: "dir", value: "js" },
+]);
+
+const EXCLUDED_FILES = new Set(["js/config.js", "js/config.example.js"]);
+
+const mode = String(process.env.JSDOC_GUARDRAIL_MODE || DEFAULT_MODE)
+  .trim()
+  .toLowerCase();
+
+if (!MODE_VALUES.has(mode)) {
+  console.error(
+    `Unsupported JSDOC_GUARDRAIL_MODE '${mode}'. Expected one of: ${Array.from(
+      MODE_VALUES
+    ).join(", ")}`
+  );
+  process.exit(1);
+}
+
+const runtimeFiles = collectRuntimeFiles().sort();
+const report = buildReport(runtimeFiles);
+
+printReport(report);
+
+if (UPDATE_BASELINE) {
+  writeBaseline(report);
+}
+
+if (mode === "warn") {
+  console.log(
+    "JSDoc guardrail is running in warning mode. Set JSDOC_GUARDRAIL_MODE=fail-on-regression to enforce baseline checks."
+  );
+  process.exit(0);
+}
+
+const baseline = loadBaselineOrFail();
+const regressions = detectRegressions(report, baseline);
+
+if (regressions.length > 0) {
+  console.error(
+    `JSDoc guardrail failed: ${regressions.length} documentation regression(s) detected.`
+  );
+  for (const regression of regressions) {
+    console.error(`- ${regression}`);
+  }
+  process.exit(1);
+}
+
+console.log("JSDoc fail-on-regression guardrail passed.");
+
+function collectRuntimeFiles() {
+  const files = new Set();
+
+  for (const target of RUNTIME_TARGETS) {
+    if (target.type === "file") {
+      const absolutePath = path.resolve(process.cwd(), target.value);
+      if (!fs.existsSync(absolutePath)) continue;
+      const relativePath = normalizePath(
+        path.relative(process.cwd(), absolutePath)
+      );
+      if (relativePath.endsWith(".js") && !EXCLUDED_FILES.has(relativePath)) {
+        files.add(relativePath);
+      }
+      continue;
+    }
+
+    if (target.type === "dir") {
+      collectDirectoryJsFiles(path.resolve(process.cwd(), target.value), files);
+    }
+  }
+
+  return Array.from(files);
+}
+
+function collectDirectoryJsFiles(directoryPath, resultSet) {
+  if (!fs.existsSync(directoryPath)) return;
+
+  const entries = fs.readdirSync(directoryPath, { withFileTypes: true });
+  for (const entry of entries) {
+    const absolutePath = path.join(directoryPath, entry.name);
+    if (entry.isDirectory()) {
+      collectDirectoryJsFiles(absolutePath, resultSet);
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    if (!entry.name.endsWith(".js")) continue;
+
+    const relativePath = normalizePath(path.relative(process.cwd(), absolutePath));
+    if (EXCLUDED_FILES.has(relativePath)) continue;
+    resultSet.add(relativePath);
+  }
+}
+
+function buildReport(files) {
+  const fileReports = [];
+  let totalFunctions = 0;
+  let documentedFunctions = 0;
+
+  for (const filePath of files) {
+    const source = fs.readFileSync(filePath, "utf8");
+    const lines = source.split(/\r?\n/);
+    const functions = collectFunctionDeclarations(lines);
+    const missing = functions.filter(
+      (entry) => !hasJsDocBlockBefore(lines, entry.lineNumber - 1)
+    );
+    const documentedCount = functions.length - missing.length;
+
+    totalFunctions += functions.length;
+    documentedFunctions += documentedCount;
+
+    fileReports.push({
+      filePath,
+      totalFunctions: functions.length,
+      documentedFunctions: documentedCount,
+      missingFunctions: missing.length,
+      coveragePercent: toCoveragePercent(documentedCount, functions.length),
+      missingDeclarations: missing,
+    });
+  }
+
+  fileReports.sort((a, b) => {
+    if (b.missingFunctions !== a.missingFunctions) {
+      return b.missingFunctions - a.missingFunctions;
+    }
+    return a.filePath.localeCompare(b.filePath);
+  });
+
+  return {
+    generatedAt: new Date().toISOString(),
+    mode,
+    totalFiles: fileReports.length,
+    totalFunctions,
+    documentedFunctions,
+    missingFunctions: totalFunctions - documentedFunctions,
+    coveragePercent: toCoveragePercent(documentedFunctions, totalFunctions),
+    files: fileReports,
+  };
+}
+
+function collectFunctionDeclarations(lines) {
+  const declarations = [];
+
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const line = lines[lineIndex];
+
+    let match = line.match(/^(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(/);
+    if (match) {
+      declarations.push({
+        name: match[1],
+        lineNumber: lineIndex + 1,
+      });
+      continue;
+    }
+
+    match = line.match(
+      /^(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?\([^)]*\)\s*=>/
+    );
+    if (match) {
+      declarations.push({
+        name: match[1],
+        lineNumber: lineIndex + 1,
+      });
+      continue;
+    }
+
+    match = line.match(
+      /^(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?[A-Za-z_$][\w$]*\s*=>/
+    );
+    if (match) {
+      declarations.push({
+        name: match[1],
+        lineNumber: lineIndex + 1,
+      });
+      continue;
+    }
+
+    match = line.match(
+      /^(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?function\s*\(/
+    );
+    if (match) {
+      declarations.push({
+        name: match[1],
+        lineNumber: lineIndex + 1,
+      });
+    }
+  }
+
+  return declarations;
+}
+
+function hasJsDocBlockBefore(lines, functionLineIndexZeroBased) {
+  let lineIndex = functionLineIndexZeroBased - 1;
+
+  while (lineIndex >= 0 && lines[lineIndex].trim() === "") {
+    lineIndex -= 1;
+  }
+
+  if (lineIndex < 0) return false;
+  if (!lines[lineIndex].includes("*/")) return false;
+
+  while (lineIndex >= 0) {
+    const line = lines[lineIndex];
+    if (line.includes("/**")) {
+      return true;
+    }
+    if (line.includes("/*") && !line.includes("/**")) {
+      return false;
+    }
+    lineIndex -= 1;
+  }
+
+  return false;
+}
+
+function toCoveragePercent(documented, total) {
+  if (total === 0) return 100;
+  return Math.round((documented / total) * 100);
+}
+
+function printReport(report) {
+  console.log(
+    `JSDoc coverage summary: ${report.documentedFunctions}/${report.totalFunctions} functions documented (${report.coveragePercent}%).`
+  );
+
+  const filesWithMissing = report.files.filter((file) => file.missingFunctions > 0);
+  if (filesWithMissing.length === 0) {
+    console.log("All scanned runtime functions have JSDoc coverage.");
+    return;
+  }
+
+  console.warn(
+    `Files with missing JSDoc declarations: ${filesWithMissing.length}/${report.totalFiles}`
+  );
+  for (const fileReport of filesWithMissing) {
+    console.warn(
+      `- ${fileReport.filePath}: missing ${fileReport.missingFunctions}/${fileReport.totalFunctions} (coverage ${fileReport.coveragePercent}%)`
+    );
+    for (const declaration of fileReport.missingDeclarations) {
+      console.warn(`  - ${declaration.name} (line ${declaration.lineNumber})`);
+    }
+  }
+}
+
+function writeBaseline(report) {
+  const baselinePayload = {
+    generatedAt: report.generatedAt,
+    totalFiles: report.totalFiles,
+    totalFunctions: report.totalFunctions,
+    documentedFunctions: report.documentedFunctions,
+    missingFunctions: report.missingFunctions,
+    coveragePercent: report.coveragePercent,
+    files: Object.fromEntries(
+      report.files.map((fileReport) => [
+        fileReport.filePath,
+        {
+          totalFunctions: fileReport.totalFunctions,
+          documentedFunctions: fileReport.documentedFunctions,
+          missingFunctions: fileReport.missingFunctions,
+          coveragePercent: fileReport.coveragePercent,
+        },
+      ])
+    ),
+  };
+
+  const outputPath = path.resolve(process.cwd(), BASELINE_FILE_PATH);
+  fs.writeFileSync(`${outputPath}`, JSON.stringify(baselinePayload, null, 2) + "\n");
+  console.log(`Updated JSDoc baseline: ${BASELINE_FILE_PATH}`);
+}
+
+function loadBaselineOrFail() {
+  const absolutePath = path.resolve(process.cwd(), BASELINE_FILE_PATH);
+  if (!fs.existsSync(absolutePath)) {
+    console.error(
+      `JSDoc baseline file not found: ${BASELINE_FILE_PATH}. Run 'npm run lint:jsdoc:update-baseline' first.`
+    );
+    process.exit(1);
+  }
+
+  try {
+    return JSON.parse(fs.readFileSync(absolutePath, "utf8"));
+  } catch (error) {
+    console.error(`Could not parse baseline file ${BASELINE_FILE_PATH}:`, error);
+    process.exit(1);
+  }
+}
+
+function detectRegressions(report, baseline) {
+  const regressions = [];
+
+  if (
+    typeof baseline.missingFunctions === "number" &&
+    report.missingFunctions > baseline.missingFunctions
+  ) {
+    regressions.push(
+      `overall missing declarations increased (${baseline.missingFunctions} -> ${report.missingFunctions})`
+    );
+  }
+
+  if (
+    typeof baseline.coveragePercent === "number" &&
+    report.coveragePercent < baseline.coveragePercent
+  ) {
+    regressions.push(
+      `overall coverage decreased (${baseline.coveragePercent}% -> ${report.coveragePercent}%)`
+    );
+  }
+
+  const baselineFiles = baseline.files && typeof baseline.files === "object"
+    ? baseline.files
+    : {};
+
+  for (const fileReport of report.files) {
+    const baselineFile = baselineFiles[fileReport.filePath];
+    if (!baselineFile) {
+      if (fileReport.missingFunctions > 0) {
+        regressions.push(
+          `${fileReport.filePath} is new in scope and has ${fileReport.missingFunctions} missing declarations`
+        );
+      }
+      continue;
+    }
+
+    if (
+      typeof baselineFile.missingFunctions === "number" &&
+      fileReport.missingFunctions > baselineFile.missingFunctions
+    ) {
+      regressions.push(
+        `${fileReport.filePath} missing declarations increased (${baselineFile.missingFunctions} -> ${fileReport.missingFunctions})`
+      );
+    }
+  }
+
+  return regressions;
+}
+
+function normalizePath(filePath) {
+  return filePath.split(path.sep).join("/");
+}

--- a/scripts/jsdoc_guardrail_baseline.json
+++ b/scripts/jsdoc_guardrail_baseline.json
@@ -1,0 +1,250 @@
+{
+  "generatedAt": "2026-02-26T12:43:16.244Z",
+  "totalFiles": 40,
+  "totalFunctions": 317,
+  "documentedFunctions": 240,
+  "missingFunctions": 77,
+  "coveragePercent": 76,
+  "files": {
+    "js/contact_popups.js": {
+      "totalFunctions": 24,
+      "documentedFunctions": 1,
+      "missingFunctions": 23,
+      "coveragePercent": 4
+    },
+    "js/filepicker.js": {
+      "totalFunctions": 23,
+      "documentedFunctions": 0,
+      "missingFunctions": 23,
+      "coveragePercent": 0
+    },
+    "js/ui-event-delegation.js": {
+      "totalFunctions": 13,
+      "documentedFunctions": 0,
+      "missingFunctions": 13,
+      "coveragePercent": 0
+    },
+    "js/storage.js": {
+      "totalFunctions": 21,
+      "documentedFunctions": 11,
+      "missingFunctions": 10,
+      "coveragePercent": 52
+    },
+    "js/addTask_tasks.js": {
+      "totalFunctions": 19,
+      "documentedFunctions": 15,
+      "missingFunctions": 4,
+      "coveragePercent": 79
+    },
+    "js/runtime-fallbacks.js": {
+      "totalFunctions": 7,
+      "documentedFunctions": 4,
+      "missingFunctions": 3,
+      "coveragePercent": 57
+    },
+    "js/help.js": {
+      "totalFunctions": 1,
+      "documentedFunctions": 0,
+      "missingFunctions": 1,
+      "coveragePercent": 0
+    },
+    "js/addTask_dropdown.js": {
+      "totalFunctions": 0,
+      "documentedFunctions": 0,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/addTask_form_domain.js": {
+      "totalFunctions": 0,
+      "documentedFunctions": 0,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/addTask_keyboard.js": {
+      "totalFunctions": 0,
+      "documentedFunctions": 0,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/addTask_ui.js": {
+      "totalFunctions": 0,
+      "documentedFunctions": 0,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/addTask.js": {
+      "totalFunctions": 37,
+      "documentedFunctions": 37,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/auth.js": {
+      "totalFunctions": 14,
+      "documentedFunctions": 14,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/board_drag_and_drop.js": {
+      "totalFunctions": 5,
+      "documentedFunctions": 5,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/board_media.js": {
+      "totalFunctions": 5,
+      "documentedFunctions": 5,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/board_popups.js": {
+      "totalFunctions": 10,
+      "documentedFunctions": 10,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/board_rendering.js": {
+      "totalFunctions": 12,
+      "documentedFunctions": 12,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/board_state.js": {
+      "totalFunctions": 13,
+      "documentedFunctions": 13,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/board.js": {
+      "totalFunctions": 1,
+      "documentedFunctions": 1,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/contact_list.js": {
+      "totalFunctions": 3,
+      "documentedFunctions": 3,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/contact_popups_mutations.js": {
+      "totalFunctions": 0,
+      "documentedFunctions": 0,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/contact_popups_overlay.js": {
+      "totalFunctions": 0,
+      "documentedFunctions": 0,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/contact_popups_validation.js": {
+      "totalFunctions": 0,
+      "documentedFunctions": 0,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/contacts_render.js": {
+      "totalFunctions": 5,
+      "documentedFunctions": 5,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/contacts.js": {
+      "totalFunctions": 22,
+      "documentedFunctions": 22,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/cookiebot-bootstrap.js": {
+      "totalFunctions": 3,
+      "documentedFunctions": 3,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/helper_dom.js": {
+      "totalFunctions": 0,
+      "documentedFunctions": 0,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/helper_focus.js": {
+      "totalFunctions": 0,
+      "documentedFunctions": 0,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/helper_sanitize.js": {
+      "totalFunctions": 0,
+      "documentedFunctions": 0,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/helper.js": {
+      "totalFunctions": 0,
+      "documentedFunctions": 0,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/login.js": {
+      "totalFunctions": 18,
+      "documentedFunctions": 18,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/privacy_and_legal.js": {
+      "totalFunctions": 3,
+      "documentedFunctions": 3,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/responsive-navigation.js": {
+      "totalFunctions": 11,
+      "documentedFunctions": 11,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/signUp.js": {
+      "totalFunctions": 17,
+      "documentedFunctions": 17,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/storage_compat_fallbacks.js": {
+      "totalFunctions": 0,
+      "documentedFunctions": 0,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/storage_error_policy.js": {
+      "totalFunctions": 0,
+      "documentedFunctions": 0,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/storage_firebase_adapter.js": {
+      "totalFunctions": 0,
+      "documentedFunctions": 0,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/storage_transport.js": {
+      "totalFunctions": 0,
+      "documentedFunctions": 0,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "js/summary.js": {
+      "totalFunctions": 16,
+      "documentedFunctions": 16,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    },
+    "script.js": {
+      "totalFunctions": 14,
+      "documentedFunctions": 14,
+      "missingFunctions": 0,
+      "coveragePercent": 100
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This PR implements ticket #113 by adding an automated JSDoc guardrail for runtime JavaScript and integrating it into CI.

## What changed

### 1) New JSDoc guardrail script
- Added `scripts/check_jsdoc_coverage.cjs`
- Scans runtime JS scope (`script.js` + `js/**/*.js`, excluding config files)
- Reports missing JSDoc per file/function
- Supports two modes:
  - `warn` (default): report-only, no failure
  - `fail-on-regression`: compares against baseline and fails on regression

### 2) Baseline for regression mode
- Added `scripts/jsdoc_guardrail_baseline.json`
- Captures current documentation baseline to enable staged enforcement

### 3) CI integration
- Updated `.github/workflows/pr-tests.yml`
- Added JSDoc guardrail step in warning mode:
  - `JSDOC_GUARDRAIL_MODE=warn`
  - `npm run lint:jsdoc`

### 4) Local scripts and docs
- Updated `package.json`:
  - `lint:jsdoc`
  - `lint:jsdoc:update-baseline`
- Added `JSDOC_GUARDRAILS.md` with:
  - scope
  - commands
  - mode behavior
  - regression policy
- Updated references in:
  - `README.md`
  - `ENGINEERING_STANDARDS.md`

## Validation
- `npm run lint:jsdoc` ✅
- `JSDOC_GUARDRAIL_MODE=fail-on-regression npm run lint:jsdoc` ✅
- `npm run lint:js` ✅
- `npm run lint:file-size` ✅
- `npm run lint` ✅

## Notes
- This is intentionally staged as warning-only in CI for now.
- Fail-on-regression mode is implemented and can be switched on once the team decides the baseline is stable.

Closes #113.
