### PR TITLE
chore: backfill jsdoc for board add-task and filepicker flows

### DIFF
--- a/js/addTask_dropdown.js
+++ b/js/addTask_dropdown.js
@@ -8,6 +8,7 @@
 
     let atdActiveDropdownState = null;
 
+    /** Toggles a dropdown panel via arrow interaction and updates close-target wiring. */
     function atdRenderArrow(arrowContainerId, contentContainerId) {
         const dropdownContainer = document.getElementById(contentContainerId);
         if (!dropdownContainer) {
@@ -25,6 +26,7 @@
         atdSetCloseDropdownContainer();
     }
 
+    /** Opens a dropdown panel, updates arrow/icon state, and stores opener focus context. */
     function atdOpenDropdown(arrowContainerId, contentContainerId) {
         const dropdownContainer = document.getElementById(contentContainerId);
         if (!dropdownContainer) {
@@ -57,6 +59,7 @@
         atdFocusFirstDropdownControl(dropdownContainer);
     }
 
+    /** Closes a dropdown panel and optionally restores focus to the opening control. */
     function atdCloseDropdown(contentContainerId, options = {}) {
         const dropdownContainer = document.getElementById(contentContainerId);
         if (!dropdownContainer || !dropdownContainer.classList.contains("dropdown-opened")) {
@@ -104,6 +107,7 @@
         return true;
     }
 
+    /** Closes all opened add-task dropdown panels in deterministic order. */
     function atdCloseOpenDropdowns(options = {}) {
         const { restoreFocus = false } = options;
         const openedDropdowns = Array.from(
@@ -124,6 +128,7 @@
         return true;
     }
 
+    /** Initializes baseline ARIA attributes for add-task dropdown trigger buttons. */
     function atdInitializeDropdownAccessibilityState() {
         document
             .querySelectorAll(
@@ -135,6 +140,7 @@
             });
     }
 
+    /** Moves focus to the first keyboard-focusable control inside a dropdown panel. */
     function atdFocusFirstDropdownControl(dropdownContainer) {
         if (!dropdownContainer) {
             return;
@@ -145,6 +151,7 @@
         focusElementIfPossible(firstControl);
     }
 
+    /** Updates delegated outside-click action attributes for currently opened dropdowns. */
     function atdSetCloseDropdownContainer() {
         const openedDropdowns = document.getElementsByClassName("dropdown-opened");
         const container = atdGetContainerToSetDropdownCloseAction();
@@ -173,6 +180,7 @@
         delete container.dataset.contentContainer;
     }
 
+    /** Resolves the DOM container used for delegated dropdown-close interactions. */
     function atdGetContainerToSetDropdownCloseAction() {
         if (window.location.href.includes("addTask")) {
             return document.getElementById("bodyContent");
@@ -185,10 +193,12 @@
         return document.getElementById("addTaskHoverContainer");
     }
 
+    /** Returns the currently tracked active dropdown focus/opener state. */
     function atdGetActiveDropdownState() {
         return atdActiveDropdownState;
     }
 
+    /** Clears tracked active dropdown state after close/teardown flows. */
     function atdClearActiveDropdownState() {
         atdActiveDropdownState = null;
     }

--- a/js/addTask_form_domain.js
+++ b/js/addTask_form_domain.js
@@ -1,6 +1,7 @@
 "use strict";
 
 (function registerAddTaskFormDomainModule() {
+    /** Sets today's date as minimum allowed value for due-date input. */
     function atfSetTodayDateAsMin() {
         let date = new Date();
         let day = date.getDate();
@@ -17,6 +18,7 @@
         }
     }
 
+    /** Registers required-field validation handlers and computes initial validity state. */
     function atfCheckValidity() {
         if (!atfHasRequiredInputFields()) {
             return;
@@ -33,6 +35,7 @@
         });
     }
 
+    /** Returns current validity state for one required field descriptor. */
     function atfGetStateOfRequriredField(requiredInputField) {
         let inputField = document.getElementById(requiredInputField.id);
         if (!inputField) {
@@ -48,6 +51,7 @@
         return true;
     }
 
+    /** Enables or disables create button based on aggregate required-field state. */
     function atfSetCreateBtnState() {
         if (!atfHasRequiredInputFields()) {
             atfDeactivateButton("createBtn");
@@ -61,6 +65,7 @@
         }
     }
 
+    /** Activates an action button and updates accessibility state attributes. */
     function atfActivateButton(id, actionName) {
         const button = document.getElementById(id);
         if (!button) {
@@ -78,6 +83,7 @@
         }
     }
 
+    /** Deactivates an action button and removes delegated action mapping. */
     function atfDeactivateButton(id) {
         const button = document.getElementById(id);
         if (!button) {
@@ -92,6 +98,7 @@
         delete button.dataset.action;
     }
 
+    /** Maps add-task form inputs into the provided task draft payload object. */
     function atfMapTaskPayloadFromForm(taskDraft, options = {}) {
         if (!taskDraft || typeof taskDraft !== "object") {
             return taskDraft;
@@ -117,6 +124,7 @@
         return taskDraft;
     }
 
+    /** Renders or clears required-field validation feedback for one field descriptor. */
     function atfToggleRequiredMessage(requiredInputField) {
         let requiredMessageField = document.getElementById(requiredInputField.requiredFieldId);
         let toUnderline = document.getElementById(requiredInputField.idForRedUnderline);
@@ -153,6 +161,7 @@
         atfSetCreateBtnState();
     }
 
+    /** Ensures required field configuration exists before binding validation logic. */
     function atfHasRequiredInputFields() {
         return typeof requiredInputFields !== "undefined" && Array.isArray(requiredInputFields);
     }

--- a/js/addTask_tasks.js
+++ b/js/addTask_tasks.js
@@ -274,6 +274,7 @@ function getNewTaskId(){
     return generateCollisionSafeId(tasks);
 }
 
+/** Marks a task id for patch upsert and removes conflicting pending delete state. */
 function queueTaskUpsert(taskId){
     const normalizedId = Number(taskId);
     if (!Number.isSafeInteger(normalizedId)) {
@@ -283,6 +284,7 @@ function queueTaskUpsert(taskId){
     pendingTaskUpserts.add(normalizedId);
 }
 
+/** Marks a task id for deletion and removes conflicting pending upsert state. */
 function queueTaskDelete(taskId){
     const normalizedId = Number(taskId);
     if (!Number.isSafeInteger(normalizedId)) {
@@ -292,6 +294,7 @@ function queueTaskDelete(taskId){
     pendingTaskDeletes.add(normalizedId);
 }
 
+/** Builds a sparse Firebase patch payload for the given task id list. */
 function buildTaskPatchPayload(taskIds){
     const payload = {};
     taskIds.forEach((id) => {
@@ -303,6 +306,7 @@ function buildTaskPatchPayload(taskIds){
     return payload;
 }
 
+/** Resolves a task entity by id from the in-memory tasks collection. */
 function getTaskById(taskId){
     for (let i = 0; i < tasks.length; i++) {
         if (Number(tasks[i].id) === Number(taskId)) {

--- a/js/addTask_ui.js
+++ b/js/addTask_ui.js
@@ -1,11 +1,13 @@
 "use strict";
 
 (function registerAddTaskUiModule() {
+    /** Sets add-task priority and syncs visual state plus task draft payload. */
     function atuSetPriority(priority) {
         atuSetPriorityAppearance(priority);
         setPriorityForNewCard(priority);
     }
 
+    /** Applies active styling/icons for the selected priority button group. */
     function atuSetPriorityAppearance(priority) {
         document.querySelectorAll(".addTaskPriorityButton").forEach((button) => {
             button.style.backgroundColor = "white";
@@ -27,6 +29,7 @@
             `./assets/img/icon-priority_${priority.toLowerCase()}_white.png`;
     }
 
+    /** Replaces the subtask footer with an editable subtask input and focuses it. */
     function atuRenderSubtaskInputField() {
         let subtaskBottom = document.getElementById("subtaskBottom");
         if (!subtaskBottom) {
@@ -40,6 +43,7 @@
         }
     }
 
+    /** Handles add/cancel actions from the subtask input footer controls. */
     function atuSubtaskAddOrCancel(option) {
         let subtaskBottom = document.getElementById("subtaskBottom");
         let subtaskInputField = document.getElementById("subtaskInputField");
@@ -55,6 +59,7 @@
         subtaskBottom.dataset.action = "render-subtask-input-field";
     }
 
+    /** Renders all draft subtasks into the add-task output container. */
     function atuRenderSubtasks() {
         let outputContainer = document.getElementById("subtasksOutputContainer");
         if (!outputContainer) {
@@ -68,6 +73,7 @@
         }
     }
 
+    /** Returns true when any subtask row is currently in inline edit mode. */
     function atuCheckIfAnySubtaskIsInEditingMode() {
         let subtaskContainers = document.getElementsByClassName("subTaskOutputDiv");
         for (let i = 0; i < subtaskContainers.length; i++) {
@@ -79,6 +85,7 @@
         return false;
     }
 
+    /** Maps a priority value to its configured add-task button color. */
     function atuGetButtonColor(priority) {
         switch (priority) {
             case "urgent":
@@ -92,6 +99,7 @@
         }
     }
 
+    /** Renders contact options into the assigned-to dropdown list. */
     function atuRenderContactsToDropdown() {
         let content = document.getElementById("dropdown-content-assignedTo");
         if (!content) {
@@ -109,6 +117,7 @@
         });
     }
 
+    /** Opens the browser date picker for the due-date field when supported. */
     function atuAddTaskDueDateOpenCalendear() {
         const dueDateInput = document.getElementById("addTaskDueDateInput");
         if (dueDateInput && typeof dueDateInput.showPicker === "function") {
@@ -116,6 +125,7 @@
         }
     }
 
+    /** Toggles selected appearance and checkbox icon for an assigned contact row. */
     function atuSetDropdownContactAppearance(dropdownContact, dropdownCheckboxImage) {
         if (!dropdownContact || !dropdownCheckboxImage) {
             return;
@@ -130,6 +140,7 @@
         }
     }
 
+    /** Shows or hides the assigned-contact badge container based on selection state. */
     function atuToggleAssignedContactsContainer() {
         let contactCards = document.getElementById("dropdown-content-assignedTo")?.childNodes;
         let assignedContactsContainer = document.getElementById("assignedContactsContainer");
@@ -151,6 +162,7 @@
         }
     }
 
+    /** Renders assigned contact badges from temporary contact id state. */
     function atuRenderAssignedContactsContainer() {
         let container = document.getElementById("assignedContactsContainer");
         if (!container) {
@@ -164,6 +176,7 @@
         });
     }
 
+    /** Applies selected category and closes category dropdown accessibility state. */
     function atuChooseCategory(chosenCategory) {
         let categoryContainer = document.getElementById("dropdown-category-title");
         if (categoryContainer) {
@@ -184,6 +197,7 @@
         newTask.type = chosenCategory;
     }
 
+    /** Checks whether any element in the current DOM is marked with editing mode. */
     function atuCheckIfCardIsEditing() {
         let editing = document.getElementsByTagName("*");
         for (let element of editing) {

--- a/js/filepicker.js
+++ b/js/filepicker.js
@@ -11,6 +11,7 @@ setTimeout(() => {
   initializeFilepickerUI();
 }, 1000);
 
+/** Initializes filepicker listeners and drag/drop observers once image UI is present. */
 function initializeFilepickerUI() {
   if (!hasRenderedAddTaskImageUi()) {
     observeDropArea();
@@ -24,6 +25,7 @@ function initializeFilepickerUI() {
   observeContainer();
 }
 
+/** Opens the hidden native file input used for image uploads. */
 function openFilepicker() {
   const filepicker = document.getElementById("filepicker");
   if (filepicker) {
@@ -33,6 +35,7 @@ function openFilepicker() {
   }
 }
 
+/** Attaches the file input change listener exactly once. */
 function addFilepickerListener() {
   const filepicker = document.getElementById("filepicker");
   if (!filepicker) return;
@@ -49,6 +52,7 @@ function addFilepickerListener() {
   });
 }
 
+/** Registers drag/drop handlers on the add-task drop zone when available. */
 function setupDragAndDrop() {
   const dropArea = document.getElementById("addImageBottom");
   if (!dropArea) {
@@ -87,6 +91,7 @@ function setupDragAndDrop() {
   return true;
 }
 
+/** Binds global drag/drop prevention listeners once per page runtime. */
 function bindGlobalDragAndDropListeners() {
   if (globalDragAndDropListenersBound) {
     return;
@@ -97,10 +102,12 @@ function bindGlobalDragAndDropListeners() {
   globalDragAndDropListenersBound = true;
 }
 
+/** Prevents browser default drag/drop navigation behavior. */
 function preventDefaultDragBehavior(event) {
   event.preventDefault();
 }
 
+/** Observes DOM mutations until the add-task drop zone exists, then wires listeners. */
 function observeDropArea() {
   if (dropAreaObserver || !document.body) {
     return;
@@ -121,6 +128,7 @@ function observeDropArea() {
   dropAreaObserver.observe(document.body, { childList: true, subtree: true });
 }
 
+/** Processes a FileList and forwards valid image files to async processing. */
 function handleFiles(files, container) {
   Array.from(files).forEach((file) => {
     if (!isImageFile(file)) {
@@ -131,10 +139,12 @@ function handleFiles(files, container) {
   });
 }
 
+/** Checks whether a file has an image MIME type. */
 function isImageFile(file) {
   return file.type.includes("image/");
 }
 
+/** Renders a user-facing validation error for unsupported files. */
 function displayFileError(file) {
   const errorEl = document.getElementById("error");
   if (errorEl) {
@@ -142,6 +152,7 @@ function displayFileError(file) {
   }
 }
 
+/** Compresses and appends one image preview, then refreshes preview rendering state. */
 async function processFile(file, container) {
   if (!container) {
     console.error("Kein Container gefunden zum Anhängen des Bildes.");
@@ -154,6 +165,7 @@ async function processFile(file, container) {
   renderAddTaskImages();
 }
 
+/** Compresses an image file to a bounded JPEG data URL for storage and preview. */
 async function compressImage(file, maxWidth, maxHeight, quality) {
   try {
     const img = await loadImageFromFile(file);
@@ -166,6 +178,7 @@ async function compressImage(file, maxWidth, maxHeight, quality) {
   }
 }
 
+/** Loads an image element from a File object URL. */
 function loadImageFromFile(file) {
   return new Promise((resolve, reject) => {
     const img = new Image();
@@ -175,6 +188,7 @@ function loadImageFromFile(file) {
   });
 }
 
+/** Calculates scaled dimensions that fit inside the configured bounds. */
 function calculateScaledDimensions(img, maxWidth, maxHeight) {
   const { width, height } = img;
   const scale = Math.min(maxWidth / width, maxHeight / height, 1);
@@ -184,6 +198,7 @@ function calculateScaledDimensions(img, maxWidth, maxHeight) {
   };
 }
 
+/** Draws an image into a temporary canvas used for compression output. */
 function drawImageOnCanvas(img, width, height) {
   const canvas = document.createElement("canvas");
   canvas.width = width;
@@ -193,6 +208,7 @@ function drawImageOnCanvas(img, width, height) {
   return canvas;
 }
 
+/** Creates a standardized 100x100 preview image element for thumbnail lists. */
 function createImageElement(src) {
   const img = document.createElement("img");
   img.src = src;
@@ -203,6 +219,7 @@ function createImageElement(src) {
   return img;
 }
 
+/** Persists uploaded image metadata in the in-memory image collection. */
 function addImageToArray(file, compressedbase64) {
   allImages.push({
     name: file.name,
@@ -211,6 +228,7 @@ function addImageToArray(file, compressedbase64) {
   });
 }
 
+/** Re-renders thumbnail previews and reinitializes the Viewer.js gallery binding. */
 function renderAddTaskImages() {
   const container = getCurrentImageContainer();
   if (!container) {
@@ -240,6 +258,7 @@ function renderAddTaskImages() {
   initializeViewer();
 }
 
+/** Creates or refreshes the global Viewer.js instance for task image previews. */
 function initializeViewer() {
   const container = document.getElementById("subtasksImageContainer");
   if (!container) return;
@@ -251,6 +270,7 @@ function initializeViewer() {
   window.addTaskViewer = new Viewer(container, getDefaultViewerOptions());
 }
 
+/** Returns default Viewer.js toolbar/options used across add-task image previews. */
 function getDefaultViewerOptions() {
   return {
     navbar: false,
@@ -273,6 +293,7 @@ function getDefaultViewerOptions() {
 }
 
 
+/** Resolves the active preview container and creates a fallback container when needed. */
 function getCurrentImageContainer() {
   let editContainer = document.getElementById("editCardImagesContainer");
   let standardContainer = document.getElementById("subtasksImageContainer");
@@ -291,6 +312,7 @@ function getCurrentImageContainer() {
   return null;
 }
 
+/** Indicates whether add-task image UI containers are currently mounted in the DOM. */
 function hasRenderedAddTaskImageUi() {
   return Boolean(
     document.getElementById("subtasksImageContainer") ||
@@ -299,6 +321,7 @@ function hasRenderedAddTaskImageUi() {
   );
 }
 
+/** Observes DOM changes to bootstrap image rendering once preview containers appear. */
 function observeContainer() {
   if (document.getElementById("subtasksImageContainer")) {
     addFilepickerListener();


### PR DESCRIPTION
## Summary
This PR implements ticket #114 by backfilling JSDoc coverage in board/add-task/filepicker-related modules.

## What changed
Added concise JSDoc to public/non-trivial functions in:

- `js/filepicker.js`
- `js/addTask_tasks.js`
- `js/addTask_ui.js`
- `js/addTask_dropdown.js`
- `js/addTask_form_domain.js`

Focus of docs:
- input/output contracts
- UI side effects (DOM updates, dropdown/focus behavior, drag & drop/image rendering)
- assumptions used in interaction-heavy flows

## Notes
- No intended behavior changes.
- Documentation-only pass for runtime clarity and safer refactor reviews.

## Validation
- Target modules now report no missing top-level function JSDoc.
- `npm run lint:jsdoc` ✅
- `npm run lint:js` ✅
- `npm run lint:file-size` ✅ (warnings only, no hard failures)

Closes #114.
