### PR TITLE
chore: backfill jsdoc for contacts popup flow modules

### DIFF
--- a/js/contact_popups.js
+++ b/js/contact_popups.js
@@ -7,6 +7,15 @@
  * while implementation details live in focused modules.
  */
 
+/**
+ * Invokes a contact-popup module method behind a stable facade API.
+ *
+ * @param {string} moduleName - Global module namespace (e.g. `ContactPopupOverlay`).
+ * @param {string} methodName - Method name on the resolved module.
+ * @param {Array<any>} [args=[]] - Positional arguments forwarded to the method.
+ * @param {any} fallbackValue - Value returned when module/method is unavailable.
+ * @returns {any}
+ */
 function callContactPopupModuleMethod(moduleName, methodName, args = [], fallbackValue) {
   const moduleRef = window[moduleName];
   if (!moduleRef || typeof moduleRef[methodName] !== "function") {
@@ -18,6 +27,7 @@ function callContactPopupModuleMethod(moduleName, methodName, args = [], fallbac
   return moduleRef[methodName](...args);
 }
 
+/** Saves a new contact using the mutations module flow. */
 async function saveContact() {
   return callContactPopupModuleMethod(
     "ContactPopupMutations",
@@ -27,6 +37,7 @@ async function saveContact() {
   );
 }
 
+/** Opens and initializes the "add contact" overlay card. */
 function addContactCard() {
   return callContactPopupModuleMethod(
     "ContactPopupOverlay",
@@ -36,6 +47,12 @@ function addContactCard() {
   );
 }
 
+/**
+ * Closes a contact overlay by element id.
+ *
+ * @param {string} id - Overlay container id to close.
+ * @returns {void}
+ */
 function closeOverlay(id) {
   return callContactPopupModuleMethod(
     "ContactPopupOverlay",
@@ -45,6 +62,7 @@ function closeOverlay(id) {
   );
 }
 
+/** Opens the responsive edit/delete action menu for contacts. */
 function openEditDelete() {
   return callContactPopupModuleMethod(
     "ContactPopupOverlay",
@@ -54,6 +72,12 @@ function openEditDelete() {
   );
 }
 
+/**
+ * Closes responsive edit/delete menu and optionally restores opener focus.
+ *
+ * @param {{restoreFocus?: boolean}} [options={}] - Menu close behavior options.
+ * @returns {void}
+ */
 function closeEditDelete(options = {}) {
   return callContactPopupModuleMethod(
     "ContactPopupOverlay",
@@ -63,6 +87,12 @@ function closeEditDelete(options = {}) {
   );
 }
 
+/**
+ * Starts contact edit flow for a contact id.
+ *
+ * @param {number} id - Contact id to edit.
+ * @returns {void}
+ */
 function editContact(id) {
   return callContactPopupModuleMethod(
     "ContactPopupMutations",
@@ -72,6 +102,12 @@ function editContact(id) {
   );
 }
 
+/**
+ * Persists edited contact values for one contact id.
+ *
+ * @param {number} id - Contact id being edited.
+ * @returns {Promise<void>}
+ */
 async function saveEditedContact(id) {
   return callContactPopupModuleMethod(
     "ContactPopupMutations",
@@ -81,6 +117,12 @@ async function saveEditedContact(id) {
   );
 }
 
+/**
+ * Removes a contact by id through mutations module orchestration.
+ *
+ * @param {number} id - Contact id to remove.
+ * @returns {Promise<void>}
+ */
 async function removeContact(id) {
   return callContactPopupModuleMethod(
     "ContactPopupMutations",
@@ -90,6 +132,12 @@ async function removeContact(id) {
   );
 }
 
+/**
+ * Opens edit overlay pre-filled with contact values.
+ *
+ * @param {Object} contact - Contact object shown in edit form.
+ * @returns {void}
+ */
 function editContactCard(contact) {
   return callContactPopupModuleMethod(
     "ContactPopupOverlay",
@@ -99,6 +147,7 @@ function editContactCard(contact) {
   );
 }
 
+/** Makes sure add-contact container is visible in the current layout context. */
 function showAddContactContainer() {
   return callContactPopupModuleMethod(
     "ContactPopupOverlay",
@@ -108,6 +157,12 @@ function showAddContactContainer() {
   );
 }
 
+/**
+ * Shows a transient contacts success message overlay.
+ *
+ * @param {string} message - User-facing success text.
+ * @returns {void}
+ */
 function displaySuccessMessage(message) {
   return callContactPopupModuleMethod(
     "ContactPopupMutations",
@@ -117,6 +172,13 @@ function displaySuccessMessage(message) {
   );
 }
 
+/**
+ * Refreshes contacts UI state after a create/edit/delete mutation.
+ *
+ * @param {Array<Object>} sourceUsers - Updated users data source.
+ * @param {number|null} [selectedContactId=null] - Optional contact id to reopen.
+ * @returns {void}
+ */
 function applyContactsMutationResult(sourceUsers, selectedContactId = null) {
   return callContactPopupModuleMethod(
     "ContactPopupMutations",
@@ -126,6 +188,12 @@ function applyContactsMutationResult(sourceUsers, selectedContactId = null) {
   );
 }
 
+/**
+ * Removes one contact entry from legacy local-storage contacts cache.
+ *
+ * @param {number} contactId - Contact id to remove from cache.
+ * @returns {void}
+ */
 function deleteContactFromLocalStorage(contactId) {
   return callContactPopupModuleMethod(
     "ContactPopupMutations",
@@ -135,6 +203,12 @@ function deleteContactFromLocalStorage(contactId) {
   );
 }
 
+/**
+ * Deletes one contact remotely and applies resulting local UI refresh.
+ *
+ * @param {number} id - Contact id to delete.
+ * @returns {Promise<void>}
+ */
 async function deleteContact(id) {
   return callContactPopupModuleMethod(
     "ContactPopupMutations",
@@ -144,6 +218,11 @@ async function deleteContact(id) {
   );
 }
 
+/**
+ * Returns key contact-form controls used by create/edit flows.
+ *
+ * @returns {{nameInput: HTMLInputElement|null, mailInput: HTMLInputElement|null, phoneInput: HTMLInputElement|null, createButton: HTMLElement|null}}
+ */
 function getContactFormElements() {
   return callContactPopupModuleMethod(
     "ContactPopupValidation",
@@ -158,6 +237,12 @@ function getContactFormElements() {
   );
 }
 
+/**
+ * Validates required contact form fields and formats.
+ *
+ * @param {Object} formElements - Input references returned by `getContactFormElements`.
+ * @returns {boolean}
+ */
 function validateContactFormFields(formElements) {
   return callContactPopupModuleMethod(
     "ContactPopupValidation",
@@ -167,6 +252,13 @@ function validateContactFormFields(formElements) {
   );
 }
 
+/**
+ * Sets one contact input field into invalid state with message output.
+ *
+ * @param {HTMLInputElement|null} inputElement - Input to mark invalid.
+ * @param {string} message - Error text for field-level feedback.
+ * @returns {void}
+ */
 function setContactFieldError(inputElement, message) {
   return callContactPopupModuleMethod(
     "ContactPopupValidation",
@@ -176,6 +268,12 @@ function setContactFieldError(inputElement, message) {
   );
 }
 
+/**
+ * Clears invalid state and field-level messages for contact form inputs.
+ *
+ * @param {Object} formElements - Input references returned by `getContactFormElements`.
+ * @returns {void}
+ */
 function clearContactFieldErrors(formElements) {
   return callContactPopupModuleMethod(
     "ContactPopupValidation",
@@ -185,6 +283,12 @@ function clearContactFieldErrors(formElements) {
   );
 }
 
+/**
+ * Resets contact form values and validation state.
+ *
+ * @param {Object} [formElements=getContactFormElements()] - Form element references.
+ * @returns {void}
+ */
 function resetContactForm(formElements = getContactFormElements()) {
   return callContactPopupModuleMethod(
     "ContactPopupValidation",
@@ -194,6 +298,12 @@ function resetContactForm(formElements = getContactFormElements()) {
   );
 }
 
+/**
+ * Writes provided contact values into active form inputs.
+ *
+ * @param {{name: string, mail: string, phone: string}} values - Values to apply.
+ * @returns {void}
+ */
 function setContactFormValues(values) {
   return callContactPopupModuleMethod(
     "ContactPopupValidation",
@@ -203,6 +313,12 @@ function setContactFormValues(values) {
   );
 }
 
+/**
+ * Normalizes contact email values for duplicate checks and persistence.
+ *
+ * @param {string} emailValue - Raw email value.
+ * @returns {string}
+ */
 function normalizeEmailForContactFlow(emailValue) {
   return callContactPopupModuleMethod(
     "ContactPopupValidation",
@@ -212,6 +328,12 @@ function normalizeEmailForContactFlow(emailValue) {
   );
 }
 
+/**
+ * Checks whether a contact email is already present in current users list.
+ *
+ * @param {string} emailValue - Candidate email value.
+ * @returns {boolean}
+ */
 function contactEmailExists(emailValue) {
   return callContactPopupModuleMethod(
     "ContactPopupValidation",
@@ -221,6 +343,12 @@ function contactEmailExists(emailValue) {
   );
 }
 
+/**
+ * Checks whether all required contact form controls are available.
+ *
+ * @param {Object} formElements - Input references returned by `getContactFormElements`.
+ * @returns {boolean}
+ */
 function hasCompleteContactForm(formElements) {
   return callContactPopupModuleMethod(
     "ContactPopupValidation",

--- a/js/contact_popups_mutations.js
+++ b/js/contact_popups_mutations.js
@@ -1,6 +1,7 @@
 "use strict";
 
 (function registerContactPopupMutationsModule() {
+  /** Validates form data and creates a new contact entity in Firebase and local runtime state. */
   async function cpmSaveContact() {
     const formElements = ContactPopupValidation.getContactFormElements();
     if (!ContactPopupValidation.hasCompleteContactForm(formElements)) {
@@ -55,6 +56,12 @@
     }
   }
 
+  /**
+   * Persists edited contact data for a given contact id.
+   *
+   * @param {number} id - Contact id being edited.
+   * @returns {Promise<void>}
+   */
   async function cpmSaveEditedContact(id) {
     const loadResult = await firebaseGetArraySafe(FIREBASE_USERS_ID, {
       context: "contacts",
@@ -116,6 +123,12 @@
     cpmApplyContactsMutationResult(sourceUsers, id);
   }
 
+  /**
+   * Opens edit dialog for one contact and fills form values from current state.
+   *
+   * @param {number} id - Contact id to edit.
+   * @returns {void}
+   */
   function cpmEditContact(id) {
     ContactPopupOverlay.closeEditDelete({ restoreFocus: false });
     const contactIndex = contacts.findIndex((contact) => contact.id === id);
@@ -136,6 +149,12 @@
     currentContactId = id;
   }
 
+  /**
+   * Removes a contact id from legacy local-storage contacts cache.
+   *
+   * @param {number} contactId - Contact id to remove.
+   * @returns {void}
+   */
   function cpmDeleteContactFromLocalStorage(contactId) {
     var contactsInStorage = JSON.parse(localStorage.getItem("contacts"));
 
@@ -147,6 +166,12 @@
     }
   }
 
+  /**
+   * Deletes one contact from Firebase and updates local runtime/UI state.
+   *
+   * @param {number} id - Contact id to delete.
+   * @returns {Promise<void>}
+   */
   async function cpmDeleteContact(id) {
     const loadResult = await firebaseGetArraySafe(FIREBASE_USERS_ID, {
       context: "contacts",
@@ -169,11 +194,24 @@
     cpmApplyContactsMutationResult(sourceUsers);
   }
 
+  /**
+   * Closes responsive action menu and executes delete flow for one contact id.
+   *
+   * @param {number} id - Contact id to remove.
+   * @returns {Promise<void>}
+   */
   async function cpmRemoveContact(id) {
     ContactPopupOverlay.closeEditDelete({ restoreFocus: false });
     await cpmDeleteContact(id);
   }
 
+  /**
+   * Applies updated users array to contacts runtime and optionally reopens contact details.
+   *
+   * @param {Array<Object>} sourceUsers - Updated users array after mutation.
+   * @param {number|null} [selectedContactId=null] - Optional contact id to keep selected.
+   * @returns {void}
+   */
   function cpmApplyContactsMutationResult(sourceUsers, selectedContactId = null) {
     users = Array.isArray(sourceUsers) ? sourceUsers : [];
     getContactsOutOfUsers();
@@ -191,6 +229,12 @@
     }
   }
 
+  /**
+   * Shows transient success feedback overlay for contacts mutation operations.
+   *
+   * @param {string} message - User-facing success message.
+   * @returns {void}
+   */
   function cpmDisplaySuccessMessage(message) {
     const overlay = document.createElement("div");
     overlay.className = "contact-succ-created-overlay";

--- a/js/contact_popups_overlay.js
+++ b/js/contact_popups_overlay.js
@@ -5,6 +5,7 @@
   let contactsKeyboardAccessibilityRegistered = false;
   let editDeleteMenuOpener = null;
 
+  /** Opens the add-contact dialog, overlay backdrop, and focus trap context. */
   function cpoAddContactCard() {
     contactOverlayOpener = document.activeElement;
     if (!document.getElementById("addContact")) {
@@ -19,6 +20,12 @@
     });
   }
 
+  /**
+   * Appends a shared fullscreen overlay backdrop for contact dialogs.
+   *
+   * @param {string} overlayId - Dialog id that should close on overlay click.
+   * @returns {void}
+   */
   function cpoAddOverlay(overlayId) {
     const overlay = document.createElement("div");
     overlay.classList.add("overlay");
@@ -29,6 +36,12 @@
     document.body.style.overflow = "hidden";
   }
 
+  /**
+   * Closes a contact dialog, removes overlay backdrop, and restores scroll/focus state.
+   *
+   * @param {string} id - Dialog id to close and remove.
+   * @returns {void}
+   */
   function cpoCloseOverlay(id) {
     deactivateFocusLayer({ restoreFocus: true });
     const container = document.getElementById(id);
@@ -55,6 +68,7 @@
     }, 100);
   }
 
+  /** Creates and mounts the add-contact dialog container if missing. */
   function cpoRenderAddContacts() {
     let newDiv = document.createElement("div");
     newDiv.id = "addContact";
@@ -67,6 +81,7 @@
     document.getElementById("addContactContainer").appendChild(newDiv);
   }
 
+  /** Creates and mounts the edit-contact dialog container if missing. */
   function cpoRenderEditContact() {
     let newDiv = document.createElement("div");
     newDiv.id = "editContact";
@@ -78,11 +93,13 @@
     document.getElementById("contactMainEdit").appendChild(newDiv);
   }
 
+  /** Unhides the add-contact host container in responsive layouts. */
   function cpoShowAddContactContainer() {
     const addContactContainer = document.getElementById("addContactContainer");
     addContactContainer.classList.remove("hidden");
   }
 
+  /** Opens responsive edit/delete menu and moves keyboard focus into it. */
   function cpoOpenEditDelete() {
     const openButton = document.getElementById("openEditDeleteResponsive");
     const editDeleteMenu = document.getElementById("editDelete");
@@ -102,6 +119,12 @@
     focusElementIfPossible(firstMenuButton || editDeleteMenu);
   }
 
+  /**
+   * Closes responsive edit/delete menu and optionally restores opener focus.
+   *
+   * @param {{restoreFocus?: boolean}} [options={}] - Close behavior options.
+   * @returns {void}
+   */
   function cpoCloseEditDelete(options = {}) {
     const { restoreFocus = true } = options;
     const openButton = document.getElementById("openEditDeleteResponsive");
@@ -121,6 +144,7 @@
     editDeleteMenuOpener = null;
   }
 
+  /** Registers global keyboard handling for responsive contact action menu. */
   function cpoRegisterContactsKeyboardAccessibility() {
     if (contactsKeyboardAccessibilityRegistered) {
       return;
@@ -130,6 +154,12 @@
     contactsKeyboardAccessibilityRegistered = true;
   }
 
+  /**
+   * Handles ESC and TAB focus loop behavior for responsive contact action menu.
+   *
+   * @param {KeyboardEvent} event - Native keydown event.
+   * @returns {void}
+   */
   function cpoHandleContactsKeyboardAccessibility(event) {
     const editDeleteMenu = document.getElementById("editDelete");
     if (
@@ -176,6 +206,12 @@
     }
   }
 
+  /**
+   * Opens edit-contact dialog prefilled with selected contact values.
+   *
+   * @param {{id:number,name:string,contactColor:string}} contact - Contact to edit.
+   * @returns {void}
+   */
   function cpoEditContactCard(contact) {
     contactOverlayOpener = document.activeElement;
     if (!document.getElementById("editContact")) {

--- a/js/contact_popups_validation.js
+++ b/js/contact_popups_validation.js
@@ -7,6 +7,11 @@
     contactPhone: "Please enter a phone number.",
   });
 
+  /**
+   * Returns current contact form control references used by mutation flows.
+   *
+   * @returns {{nameInput: HTMLInputElement|null, mailInput: HTMLInputElement|null, phoneInput: HTMLInputElement|null, createButton: HTMLElement|null}}
+   */
   function cpvGetContactFormElements() {
     return {
       nameInput: document.getElementById("contactName"),
@@ -16,6 +21,12 @@
     };
   }
 
+  /**
+   * Resolves field-level error output element for a given contact form input.
+   *
+   * @param {HTMLInputElement|null} inputElement - Input to resolve error element for.
+   * @returns {HTMLElement|null}
+   */
   function cpvGetContactFieldErrorElement(inputElement) {
     if (!inputElement) {
       return null;
@@ -37,6 +48,13 @@
     return document.getElementById(`${inputElement.id}Error`);
   }
 
+  /**
+   * Sets one contact form field into invalid state and writes error text.
+   *
+   * @param {HTMLInputElement|null} inputElement - Input element to mark invalid.
+   * @param {string} message - Field-level error message.
+   * @returns {void}
+   */
   function cpvSetContactFieldError(inputElement, message) {
     if (!inputElement) {
       return;
@@ -49,6 +67,12 @@
     }
   }
 
+  /**
+   * Clears invalid state and error text for one contact input field.
+   *
+   * @param {HTMLInputElement|null} inputElement - Input element to clear.
+   * @returns {void}
+   */
   function cpvClearContactFieldError(inputElement) {
     if (!inputElement) {
       return;
@@ -61,12 +85,24 @@
     }
   }
 
+  /**
+   * Clears validation feedback for all known contact form input fields.
+   *
+   * @param {{nameInput?:HTMLInputElement|null,mailInput?:HTMLInputElement|null,phoneInput?:HTMLInputElement|null}} formElements - Contact form references.
+   * @returns {void}
+   */
   function cpvClearContactFieldErrors(formElements) {
     cpvClearContactFieldError(formElements?.nameInput || null);
     cpvClearContactFieldError(formElements?.mailInput || null);
     cpvClearContactFieldError(formElements?.phoneInput || null);
   }
 
+  /**
+   * Validates required contact fields and email format constraints.
+   *
+   * @param {{nameInput:HTMLInputElement|null,mailInput:HTMLInputElement|null,phoneInput:HTMLInputElement|null}} formElements - Contact form references.
+   * @returns {boolean}
+   */
   function cpvValidateContactFormFields(formElements) {
     const { nameInput, mailInput, phoneInput } = formElements;
     let isValid = true;
@@ -98,6 +134,12 @@
     return isValid;
   }
 
+  /**
+   * Checks whether all required contact form controls are currently mounted.
+   *
+   * @param {Object} formElements - Contact form references.
+   * @returns {boolean}
+   */
   function cpvHasCompleteContactForm(formElements) {
     return Boolean(
       formElements &&
@@ -108,6 +150,12 @@
     );
   }
 
+  /**
+   * Writes provided values into contact form fields for edit flows.
+   *
+   * @param {{name:string,mail:string,phone:string}} values - Values applied to the form.
+   * @returns {void}
+   */
   function cpvSetContactFormValues(values) {
     const formElements = cpvGetContactFormElements();
     if (!formElements.nameInput || !formElements.mailInput || !formElements.phoneInput) {
@@ -119,6 +167,12 @@
     formElements.phoneInput.value = values.phone;
   }
 
+  /**
+   * Normalizes email values for duplicate checks and persistence comparisons.
+   *
+   * @param {string} emailValue - Raw email value.
+   * @returns {string}
+   */
   function cpvNormalizeEmailForContactFlow(emailValue) {
     if (typeof normalizeAuthEmail === "function") {
       return normalizeAuthEmail(emailValue);
@@ -129,6 +183,12 @@
     return emailValue.trim().toLowerCase();
   }
 
+  /**
+   * Checks whether a normalized email already exists in current users data.
+   *
+   * @param {string} emailValue - Candidate email value.
+   * @returns {boolean}
+   */
   function cpvContactEmailExists(emailValue) {
     const sourceUsers = Array.isArray(users) ? users : [];
 
@@ -153,6 +213,12 @@
     });
   }
 
+  /**
+   * Resets contact form values, error state, and create button availability.
+   *
+   * @param {Object} [formElements=cpvGetContactFormElements()] - Contact form references.
+   * @returns {void}
+   */
   function cpvResetContactForm(formElements = cpvGetContactFormElements()) {
     cpvClearContactFieldErrors(formElements);
     if (formElements.nameInput) {


### PR DESCRIPTION
## Summary
This PR implements ticket #115 by backfilling JSDoc across contacts flow modules, with no intended behavior changes.

## What changed

Added function-level JSDoc in:

- `js/contact_popups.js`
- `js/contact_popups_overlay.js`
- `js/contact_popups_validation.js`
- `js/contact_popups_mutations.js`

Documentation now covers:
- facade/wrapper contracts for public contact popup functions
- overlay lifecycle side effects (DOM insertion/removal, scroll lock, focus handling)
- keyboard/focus behavior in responsive edit/delete menu
- form validation contracts and error-state behavior
- create/edit/delete mutation flow assumptions (users state, Firebase calls, UI refresh)

## Scope
- Documentation-only pass (JSDoc/comments)
- No functional refactor intended

## Validation
- `npm run lint:jsdoc` ✅
- `npm run lint:js` ✅
- `npm run lint:file-size` ✅ (warnings only)

## Notes
- JSDoc guardrail coverage improved and contacts responsibilities are now easier to trace during refactors.

Closes #115.
