### PR TITLE
fix: recover storage runtime and global initials fallback

### DIFF
--- a/js/contacts_view.js
+++ b/js/contacts_view.js
@@ -1,25 +1,6 @@
 "use strict";
 
 /**
- * Generates initials from a full name.
- *
- * @param {string} name - The full name from which to generate initials.
- * @returns {string} The initials generated from the provided full name.
- */
-function getInitials(name) {
-  let returnName = "";
-  if (name.includes(" ")) {
-    let [firstName, lastName] = name.split(" ");
-    let firstInitial = firstName.charAt(0).toUpperCase();
-    let lastInitial = lastName.charAt(0).toUpperCase();
-    returnName = firstInitial + lastInitial;
-  } else {
-    returnName = name.charAt(0).toUpperCase();
-  }
-  return returnName;
-}
-
-/**
  * Creates a letter element representing the first letter of a group of contacts.
  *
  * @function createFirstLetter

--- a/script.js
+++ b/script.js
@@ -69,6 +69,28 @@ function getDiv(id) {
 
 
 /**
+ * Builds initials from a full name for avatar/header rendering.
+ *
+ * @param {string} name - Full name string.
+ * @returns {string} Initials (1-2 chars), defaults to "G" for empty input.
+ */
+function getInitials(name) {
+	if (typeof name !== "string" || name.trim() === "") {
+		return "G";
+	}
+
+	const nameParts = name.trim().split(/\s+/).filter(Boolean);
+	if (nameParts.length === 1) {
+		return nameParts[0].charAt(0).toUpperCase();
+	}
+
+	return (
+		nameParts[0].charAt(0) + nameParts[nameParts.length - 1].charAt(0)
+	).toUpperCase();
+}
+
+
+/**
  * rendering the board-page,
  * calling renderCategories to render all available tasks to each category
  */


### PR DESCRIPTION
## Summary
This PR completes the #118 refactor by splitting oversized runtime JS files into focused modules and applying follow-up stability fixes discovered during CI/runtime verification.

## What was done
- Reduced target runtime files below the 300-line warning threshold by moving responsibilities into dedicated modules.
- Kept existing global/runtime contracts stable across pages.
- Added follow-up fix for fallback guardrail conflict (`assertConfig` duplicate detection).
- Added runtime safety fallback so storage still initializes if `storage_runtime.js` is temporarily missing due to cache/deploy order.
- Restored a global initials helper used by shared header/runtime flows.

## Why
- Lower maintenance risk and blast radius per file.
- Cleaner module boundaries and easier future refactors.
- Better resilience for mixed-cache production states.

## Validation
- `npm run lint:js` passed
- `npm run lint` passed (only known warning-level checks remain)

## Notes
- Includes two follow-up fixes after the initial refactor commit to address CI/runtime regressions found in production-like conditions.

Closes #118
