### PR TITLE
refactor: scope domain CSS element selectors to page roots (#120)

### DIFF
--- a/ENGINEERING_STANDARDS.md
+++ b/ENGINEERING_STANDARDS.md
@@ -60,6 +60,12 @@ Avoid:
 - implicit globals
 - duplicate helper names across files
 
+CSS selector scoping:
+
+- in domain stylesheets (`board.*`, `addTask.*`, `contacts.*`, `summary.*`), avoid unscoped bare element selectors (`input`, `button`, `h1`, etc.)
+- scope element rules under domain/page roots (for example `.board-Container`, `.addTaskBody`, `body[data-init="contactsInit"]`)
+- keep truly global element styles only in explicit shared utility/base files
+
 ## 3) Module Boundaries and Ownership
 
 Ownership is domain-based. Each module has a primary responsibility:

--- a/assets/css/addTask.base.css
+++ b/assets/css/addTask.base.css
@@ -36,9 +36,9 @@
   }
 }
 
-select,
-input,
-textarea {
+:is(.addTaskBody, .addTaskHoverContainer) select,
+:is(.addTaskBody, .addTaskHoverContainer) input,
+:is(.addTaskBody, .addTaskHoverContainer) textarea {
   border: none;
   width: 100%;
   border-bottom: 1px solid rgba(0, 0, 0, 0.2);
@@ -46,32 +46,32 @@ textarea {
   margin: 0;
 }
 
-input:focus,
-select:focus,
-button:focus {
+:is(.addTaskBody, .addTaskHoverContainer) input:focus,
+:is(.addTaskBody, .addTaskHoverContainer) select:focus,
+:is(.addTaskBody, .addTaskHoverContainer) button:focus {
   outline: none;
 }
 
-input:focus {
+:is(.addTaskBody, .addTaskHoverContainer) input:focus {
   border-bottom: 1px solid var(--clr-input-focus);
 }
 
-select:hover {
+:is(.addTaskBody, .addTaskHoverContainer) select:hover {
   border-bottom: 1px solid var(--clr-input-focus);
 }
 
-textarea {
+:is(.addTaskBody, .addTaskHoverContainer) textarea {
   height: 100px;
   border: 1px solid rgba(0, 0, 0, 0.2);
   border-radius: 0 10px 10px 10px;
 }
 
-textarea:focus {
+:is(.addTaskBody, .addTaskHoverContainer) textarea:focus {
   outline: none !important;
   border: 1px solid var(--clr-input-focus);
 }
 
-select {
+:is(.addTaskBody, .addTaskHoverContainer) select {
   cursor: pointer;
 }
 
@@ -311,4 +311,3 @@ select {
 }
 
 /* Assigned To */
-

--- a/assets/css/board.base.css
+++ b/assets/css/board.base.css
@@ -192,10 +192,10 @@
   padding: 0;
 }
 
-input:focus,
-select:focus,
-textarea:focus,
-button:focus {
+.board-Container input:focus,
+.board-Container select:focus,
+.board-Container textarea:focus,
+.board-Container button:focus {
   outline: none;
 }
 
@@ -275,4 +275,3 @@ button:focus {
   color: #a8a8a8;
   width: 253px;
 }
-

--- a/assets/css/board.components.css
+++ b/assets/css/board.components.css
@@ -126,17 +126,17 @@
 }
 
 /*progress-bar*/
-progress {
+.board-Container progress {
   appearance: none;
   height: 8px;
   max-width: 125px;
 }
 
-::-webkit-progress-bar {
+.board-Container progress::-webkit-progress-bar {
   background: #f4f4f4;
   border-radius: 10px;
 }
-::-webkit-progress-value {
+.board-Container progress::-webkit-progress-value {
   background: #4589ff;
   border-radius: 10px;
 }
@@ -465,4 +465,3 @@ progress {
     display: none;
   }
 }
-

--- a/assets/css/contacts.base.css
+++ b/assets/css/contacts.base.css
@@ -262,7 +262,7 @@
   gap: 32px;
 }
 
-input {
+body[data-init="contactsInit"] input {
   justify-content: space-between;
   width: 100%;
   font-size: 19px;
@@ -293,7 +293,7 @@ input {
   color: #ff8190;
 }
 
-input::placeholder {
+body[data-init="contactsInit"] input::placeholder {
   color: #d1d1d1;
 }
 


### PR DESCRIPTION
## Title
refactor: scope domain CSS element selectors to page roots (#120)

## Summary
This PR scopes broad element selectors in domain stylesheets to their page/domain roots to reduce cross-page style bleed when multiple CSS domains are loaded together.

## Problem
Some domain CSS files used broad selectors such as `input`, `select`, `textarea`, `button`, and `progress`.  
Because pages like board/add-task/contacts include multiple domain stylesheets, these unscoped rules could leak across pages and create unintended visual side effects.

## Changes
### CSS selector scoping
- `assets/css/addTask.base.css`
  - Scoped broad form element selectors under add-task roots:
    - `:is(.addTaskBody, .addTaskHoverContainer) ...`
- `assets/css/board.base.css`
  - Scoped focus reset rules to board root:
    - `.board-Container input:focus`, etc.
- `assets/css/board.components.css`
  - Scoped progress styles to board root:
    - `.board-Container progress...`
- `assets/css/contacts.base.css`
  - Scoped contact form input rules to contacts page context:
    - `body[data-init="contactsInit"] input...`

### Guardrail convention update
- `ENGINEERING_STANDARDS.md`
  - Added explicit CSS scoping guidance:
    - avoid bare element selectors in domain stylesheets
    - scope to page/domain roots
    - keep true global element rules in shared utility/base files only

## Behavior impact
- No intended UI behavior changes.
- Existing selectors still target the same components, but now only within the correct page/domain context.

## Validation
- `npm run lint` passed.
- No CI guardrail regressions introduced.

Closes #120
