### PR TITLE
refactor: standardize CSS breakpoints via UI token strategy (#121)

### DIFF
--- a/ENGINEERING_STANDARDS.md
+++ b/ENGINEERING_STANDARDS.md
@@ -66,6 +66,12 @@ CSS selector scoping:
 - scope element rules under domain/page roots (for example `.board-Container`, `.addTaskBody`, `body[data-init="contactsInit"]`)
 - keep truly global element styles only in explicit shared utility/base files
 
+Breakpoint strategy:
+
+- use only values represented by `--ui-bp-*` tokens in `assets/css/ui-tokens.css`
+- if a new breakpoint is needed, add token first and then use the exact pixel value in CSS media queries
+- keep breakpoints consolidated and avoid one-off values when an existing token satisfies the layout need
+
 ## 3) Module Boundaries and Ownership
 
 Ownership is domain-based. Each module has a primary responsibility:

--- a/UI_TOKENS.md
+++ b/UI_TOKENS.md
@@ -4,7 +4,7 @@ This project now uses shared UI tokens from `assets/css/ui-tokens.css`.
 
 ## Breakpoints
 
-Canonical responsive breakpoints:
+Core runtime breakpoints:
 
 - `--ui-bp-mobile-max: 801px`
 - `--ui-bp-mobile-min: 802px`
@@ -12,6 +12,31 @@ Canonical responsive breakpoints:
 - `--ui-bp-phone-max: 560px`
 - `--ui-bp-content-narrow-max: 500px`
 - `--ui-bp-board-columns-max: 1400px`
+
+Approved CSS breakpoint set (v1):
+
+- `--ui-bp-desktop-max: 1200px`
+- `--ui-bp-summary-min: 1200px`
+- `--ui-bp-summary-mid-min: 600px`
+- `--ui-bp-summary-compact-max: 465px`
+- `--ui-bp-contacts-large-max: 1124px`
+- `--ui-bp-contacts-medium-max: 1010px`
+- `--ui-bp-contacts-compact-max: 890px`
+- `--ui-bp-contacts-overlay-max: 580px`
+- `--ui-bp-contacts-button-max: 420px`
+- `--ui-bp-contacts-tiny-max: 380px`
+- `--ui-bp-addtask-layout-max: 1070px`
+- `--ui-bp-auth-tablet-max: 970px`
+- `--ui-bp-auth-mobile-max: 769px`
+- `--ui-bp-auth-small-max: 680px`
+- `--ui-bp-auth-phone-max: 550px`
+- `--ui-bp-auth-compact-max: 480px`
+- `--ui-bp-privacy-max: 900px`
+- `--ui-bp-help-max: 700px`
+- `--ui-bp-help-tiny-max: 360px`
+- `--ui-bp-board-compact-max: 450px`
+- `--ui-bp-board-small-max: 400px`
+- `--ui-bp-board-tiny-max: 350px`
 
 ### JS usage
 
@@ -69,6 +94,6 @@ Layout helpers:
 
 Run `npm run lint:ui-tokens` to validate:
 
-- core breakpoint usage in CSS,
+- all HTML-referenced stylesheets (including `@import`) use only `--ui-bp-*` token values,
 - JS breakpoint fallback alignment,
 - tokenized spacing usage in key UI styles.

--- a/assets/css/contacts.responsive.css
+++ b/assets/css/contacts.responsive.css
@@ -1,4 +1,4 @@
-@media screen and (max-width: 1199px) {
+@media screen and (max-width: 1200px) {
   .contact-details-name {
     font-size: 2.25rem;
   }

--- a/assets/css/summary.responsive.css
+++ b/assets/css/summary.responsive.css
@@ -250,7 +250,7 @@
 }
 
 /*////////////////////////////////////////////////////////////////////min 700px*/
-@media (max-width: 949px) {
+@media (max-width: 950px) {
   .inner-square-button.toDo {
     display: flex;
     flex-direction: row;
@@ -260,7 +260,7 @@
   }
 }
 
-@media (min-width: 600px) and (max-width: 949px) {
+@media (min-width: 600px) and (max-width: 950px) {
   .sub-main-summary {
     padding: 16px 52px;
   }
@@ -391,7 +391,7 @@
 
 /*/ ///////////////////////////////////////////////////////////////////min    950px*/
 
-@media only screen and (min-width: 950px) and (max-width: 1204px) {
+@media only screen and (min-width: 950px) and (max-width: 1200px) {
   .summary-box {
     margin-top: 0;
     gap: 20px;
@@ -467,7 +467,7 @@
 
 /*////////////////////////////////////////////////////////////////////min 1204px*/
 /* Medium Devices, Desktops */
-@media only screen and (min-width: 1204px) {
+@media only screen and (min-width: 1200px) {
   .button-container {
     display: grid;
     grid-template-columns: 204px 204px 204px 204px;

--- a/assets/css/ui-tokens.css
+++ b/assets/css/ui-tokens.css
@@ -1,11 +1,36 @@
 :root {
   /* Responsive breakpoints (single source of truth for CSS/JS) */
+  /* Core runtime breakpoints */
   --ui-bp-mobile-max: 801px;
   --ui-bp-mobile-min: 802px;
   --ui-bp-navigation-tablet-max: 950px;
   --ui-bp-phone-max: 560px;
   --ui-bp-content-narrow-max: 500px;
   --ui-bp-board-columns-max: 1400px;
+
+  /* Shared page/layout breakpoints (approved set for CSS media queries) */
+  --ui-bp-desktop-max: 1200px;
+  --ui-bp-summary-min: 1200px;
+  --ui-bp-contacts-large-max: 1124px;
+  --ui-bp-addtask-layout-max: 1070px;
+  --ui-bp-contacts-medium-max: 1010px;
+  --ui-bp-auth-tablet-max: 970px;
+  --ui-bp-privacy-max: 900px;
+  --ui-bp-contacts-compact-max: 890px;
+  --ui-bp-auth-mobile-max: 769px;
+  --ui-bp-help-max: 700px;
+  --ui-bp-auth-small-max: 680px;
+  --ui-bp-summary-mid-min: 600px;
+  --ui-bp-contacts-overlay-max: 580px;
+  --ui-bp-auth-phone-max: 550px;
+  --ui-bp-auth-compact-max: 480px;
+  --ui-bp-summary-compact-max: 465px;
+  --ui-bp-board-compact-max: 450px;
+  --ui-bp-contacts-button-max: 420px;
+  --ui-bp-board-small-max: 400px;
+  --ui-bp-contacts-tiny-max: 380px;
+  --ui-bp-help-tiny-max: 360px;
+  --ui-bp-board-tiny-max: 350px;
 
   /* Spacing scale */
   --ui-space-0: 0;


### PR DESCRIPTION
## Title
refactor: standardize breakpoint usage via UI token strategy (#121)

## Summary
This PR standardizes responsive breakpoint usage by expanding the centralized `--ui-bp-*` token set and enforcing token-aligned media-query values across all HTML-referenced CSS files (including imported stylesheets).

## Problem
Breakpoint values were fragmented across stylesheets (`949`, `1204`, `1199`, etc.), and the previous guardrail checked only a subset of files. This made responsive behavior harder to maintain and allowed drift from the token strategy.

## What changed

### 1) Token strategy expanded
- Updated `assets/css/ui-tokens.css`
- Added a documented/approved `--ui-bp-*` set for shared page/layout breakpoints
- Kept existing core runtime breakpoints intact

### 2) CSS breakpoint alignment (targeted normalization)
- `assets/css/contacts.responsive.css`
  - `max-width: 1199px` → `max-width: 1200px`
- `assets/css/summary.responsive.css`
  - `max-width: 949px` → `max-width: 950px`
  - `(min-width: 600px) and (max-width: 949px)` → `(min-width: 600px) and (max-width: 950px)`
  - `(min-width: 950px) and (max-width: 1204px)` → `(min-width: 950px) and (max-width: 1200px)`
  - `(min-width: 1204px)` → `(min-width: 1200px)`

### 3) Guardrail coverage expanded
- Reworked `scripts/check_ui_tokens_alignment.cjs` to:
  - scan all root HTML files
  - collect all referenced CSS files
  - resolve `@import` chains recursively
  - fail if any media breakpoint value is not represented by a `--ui-bp-*` token

### 4) Documentation updated
- `UI_TOKENS.md`
  - clarified core vs approved CSS breakpoint set
  - documented guardrail behavior
- `ENGINEERING_STANDARDS.md`
  - added breakpoint strategy rules

## Validation
- `npm run lint:ui-tokens` passed
- `npm run lint` passed

## Impact
- Breakpoint usage is now centrally governed by `ui-tokens.css`
- CI now catches non-token breakpoints in newly introduced CSS changes
- Responsive behavior remains stable with only minimal numeric normalization

Closes #121
