### PR TITLE
fix: harden mobile overlay sizing for contacts board and add-task

### DIFF
--- a/assets/css/addTask.base.css
+++ b/assets/css/addTask.base.css
@@ -121,6 +121,7 @@
 
 .openCardContainer .addTaskBodyRight {
   left: 0;
+  right: auto;
 }
 
 .addTaskBodyRight {
@@ -130,7 +131,9 @@
   width: min-content;
   position: fixed;
   bottom: 55px;
-  left: 777px;
+  right: clamp(24px, 6vw, 72px);
+  left: auto;
+  max-width: calc(100vw - 32px);
 }
 
 .addTaskBtnContainer {

--- a/assets/css/addTask.responsive.css
+++ b/assets/css/addTask.responsive.css
@@ -2,11 +2,12 @@
   .addTaskBody {
     align-items: center;
     flex-direction: column;
-    width: min-content;
+    width: 100%;
+    max-width: min(100%, 920px);
   }
 
   .addTaskBodyLeft {
-    width: min-content;
+    width: 100%;
   }
 
   .addTaskBodyRight {
@@ -30,8 +31,13 @@
 }
 
 @media screen and (max-width: 560px) {
+  .addTaskBody {
+    width: 100%;
+  }
+
   .addTaskBodyTop,
   .addTaskBodyBottom {
+    width: min(100%, 400px);
     max-width: 400px;
   }
 
@@ -58,7 +64,7 @@
   }
   .addTaskBodyTop,
   .addTaskBodyBottom {
-    width: 300px;
+    width: min(100%, 300px);
   }
   .addTask-custom-select {
     font-size: medium;
@@ -69,7 +75,7 @@
   }
 
   .addTaskPriorityButton {
-    width: 100px;
+    width: clamp(88px, 26vw, 120px);
     font-size: medium;
 
     img {

--- a/assets/css/board.components.css
+++ b/assets/css/board.components.css
@@ -238,9 +238,11 @@
   top: 30px;
   left: 50%;
   transform: translateX(-50%);
-  width: 528px;
+  inline-size: min(528px, calc(100vw - clamp(24px, 6vw, 56px)));
+  max-inline-size: 100vw;
+  box-sizing: border-box;
   height: min-content;
-  max-height: calc(100% - 50px);
+  max-height: calc(100dvh - 50px);
   display: flex;
   flex-direction: column;
   gap: 5px;

--- a/assets/css/board.responsive.css
+++ b/assets/css/board.responsive.css
@@ -72,10 +72,12 @@
 
   .addTaskHoverContainer {
     position: fixed;
-    top: 20px;
-    right: var(--ui-content-gap-lg);
-    left: 20px;
-    height: 95%;
+    top: clamp(8px, 3vw, 20px);
+    right: clamp(8px, 3vw, 20px);
+    bottom: clamp(8px, 3vw, 20px);
+    left: clamp(8px, 3vw, 20px);
+    height: auto;
+    max-height: calc(100dvh - clamp(16px, 6vw, 40px));
     border-radius: 30px;
     display: flex;
     flex-direction: column;
@@ -106,7 +108,7 @@
   }
 
   .openCardContainer {
-    width: 396px;
+    inline-size: min(396px, calc(100vw - 24px));
     padding: 32px 24px 32px 24px;
 
     .openCardInnerContainer * {
@@ -144,7 +146,7 @@
     }
 
     .addTaskPriorityButton {
-      width: 100px;
+      width: clamp(88px, 26vw, 120px);
       font-size: medium;
 
       img {
@@ -160,8 +162,8 @@
 @media (max-width: 450px) {
   .openCardContainer,
   .openCardContainer[editing] {
-    /* width: clamp(290px, 100%, 400px); */
-    width: 100%;
+    inline-size: calc(100vw - 12px);
+    max-inline-size: calc(100vw - 12px);
     padding: 24px 30px 24px 30px;
   }
   .addTaskHoverContainer {

--- a/assets/css/contacts.base.css
+++ b/assets/css/contacts.base.css
@@ -72,9 +72,12 @@
 }
 
 .add-contact {
+  --contact-overlay-gap: clamp(8px, 2vw, 24px);
   top: 0;
-  width: 584px;
-  right: 0px;
+  right: 0;
+  inline-size: min(584px, calc(100vw - var(--contact-overlay-gap)));
+  max-inline-size: 100vw;
+  block-size: 100dvh;
   position: fixed;
   border-radius: 30px 0px 30px 30px;
   animation: moveInRight 125ms ease-in-out;
@@ -159,10 +162,12 @@
 }
 
 .edit-contact {
+  --contact-overlay-gap: clamp(8px, 2vw, 24px);
   top: 0;
-  width: 584px;
-  left: 0px;
-  margin-right: 159px;
+  left: 0;
+  inline-size: min(584px, calc(100vw - var(--contact-overlay-gap)));
+  max-inline-size: 100vw;
+  block-size: 100dvh;
   position: fixed;
   border-radius: 0px 30px 30px 30px;
   animation: moveInLeft 125ms ease-in-out;

--- a/assets/css/contacts.responsive.css
+++ b/assets/css/contacts.responsive.css
@@ -314,23 +314,32 @@
 @media screen and (max-width: 580px) {
   .add-contact,
   .edit-contact {
-    min-width: 100%;
-    width: auto;
-}
+    inline-size: calc(100vw - 16px);
+    max-inline-size: calc(100vw - 16px);
+  }
 
-.edit-contact p {
-  font-size: 24px;
+  .add-contact {
+    right: 8px;
+  }
+
+  .edit-contact {
+    left: 8px;
+  }
+
+  .edit-contact p {
+    font-size: 24px;
+  }
 }
 
 @media screen and (max-width: 420px) {
-  .cancelButton{
-    display: none
+  .cancelButton {
+    display: none;
   }
 
-  .add-contact-header-logo p{
+  .add-contact-header-logo p {
     font-size: 21px;
   }
-} }
+}
 
 
 @media screen and (max-width: 380px) {


### PR DESCRIPTION
## Summary
This PR hardens overlay/dialog sizing on mobile to prevent clipping and horizontal overflow across contacts, board, and add-task flows.

## Changes
- Replaced fixed overlay widths with fluid sizing (`min(...)`, `clamp(...)`) in contacts overlays.
- Removed fragile fixed positioning patterns for mobile overlays and added bounded insets.
- Updated board open-card overlay to use fluid width + viewport-safe max height.
- Reworked add-task action area positioning from fixed pixel `left` to responsive `right` anchoring.
- Adjusted mobile widths for add-task sections and priority controls.

## Why
Several overlays relied on fixed pixel values (e.g. 584px, 528px, 396px, 300px, `left: 777px`) that caused clipping/overflow on narrow viewports.

## Validation
- npm run lint:ui-tokens
- npm run lint:file-size
- npm run lint:js

## Expected outcome
- No overlay/dialog clipping on <=801px and <=560px.
- No unintended horizontal scrolling in affected overlay flows.
- Open/close/edit remains usable via touch and keyboard.
