### PR TITLE
fix(ui): harden mobile overlays for contacts, board, and add-task (#122)

### DIFF
--- a/assets/css/contacts.base.css
+++ b/assets/css/contacts.base.css
@@ -141,7 +141,10 @@
   border: solid 1px #e3e3e3;
   border-radius: 0px 0px 30px 30px;
   border-bottom: none;
-  height: 100%;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .profile-badge-group-add-contact {
@@ -223,7 +226,10 @@
   border: solid 1px #e3e3e3;
   border-radius: 0px 0px 30px 0px;
   border-bottom: none;
-  height: 100%;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .profile-badge-group-edit-contact {
@@ -248,6 +254,9 @@
   display: flex;
   flex-direction: column;
   gap: 24px;
+  width: min(100%, 420px);
+  padding-inline: 16px;
+  box-sizing: border-box;
 }
 
 @keyframes moveInLeft {
@@ -305,9 +314,13 @@ body[data-init="contactsInit"] input::placeholder {
 .addContactButton {
   display: flex;
   justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
   gap: 25px;
   margin-top: 35px;
   margin-bottom: 63px;
+  width: min(100%, 420px);
+  box-sizing: border-box;
 }
 
 .cancelButton {

--- a/assets/css/contacts.responsive.css
+++ b/assets/css/contacts.responsive.css
@@ -329,15 +329,41 @@
   .edit-contact p {
     font-size: 24px;
   }
+
+  .addContactButton {
+    gap: 12px;
+    margin-top: 20px;
+    margin-bottom: 24px;
+    width: 100%;
+  }
+
+  .cancelButton,
+  .createButton {
+    font-size: 18px;
+    min-width: 140px;
+    flex: 1 1 140px;
+    padding: 12px 14px;
+  }
+
+  .createButton img,
+  .cancelButton img {
+    padding-left: 10px;
+  }
 }
 
 @media screen and (max-width: 420px) {
-  .cancelButton {
-    display: none;
-  }
-
   .add-contact-header-logo p {
     font-size: 21px;
+  }
+
+  .addContactButton {
+    gap: 10px;
+  }
+
+  .cancelButton,
+  .createButton {
+    min-width: 0;
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary
This PR hardens mobile overlays/dialogs to prevent clipping and horizontal overflow across contacts, board, and add-task flows.

## Changes
- Replaced fixed overlay widths/positions with fluid sizing (`min(...)`, `clamp(...)`, viewport-safe sizing) for contacts, board, and add-task overlays.
- Updated board open-card overlay sizing for narrow viewports.
- Reworked add-task action-area positioning from fixed pixel placement to responsive anchoring.
- Fixed contacts edit overlay action buttons (`Cancel`/`Save`) so they stay visible and usable on small screens.
- Added mobile button wrapping/sizing and scroll-safe overlay content behavior.

## Validation
- `npm run lint:ui-tokens`
- `npm run lint:js`

## Ticket
Closes #122
