### PR TITLE
chore(ci): add stylelint css guardrail for push and pr

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -75,6 +75,24 @@ jobs:
           set -euo pipefail
           npm run a11y:audit
 
+  css-guardrails:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Guardrail check for CSS syntax and maintainability (Stylelint)
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run lint:css
+
   accessibility-baseline:
     runs-on: ubuntu-latest
 

--- a/.stylelintrc.cjs
+++ b/.stylelintrc.cjs
@@ -1,0 +1,54 @@
+module.exports = {
+  ignoreFiles: ["node_modules/**", ".lighthouseci/**"],
+  overrides: [
+    {
+      files: [
+        "assets/css/addTask.base.css",
+        "assets/css/animation.css",
+        "assets/css/board.base.css",
+        "assets/css/board.components.css",
+        "assets/css/contacts.base.css",
+        "assets/css/summary.base.css",
+        "assets/css/summary.components.css",
+      ],
+      rules: {
+        "declaration-block-no-duplicate-properties": null,
+      },
+    },
+    {
+      files: [
+        "assets/css/navigation.css",
+        "assets/css/summary.responsive.css",
+      ],
+      rules: {
+        "declaration-block-no-shorthand-property-overrides": null,
+      },
+    },
+  ],
+  rules: {
+    "at-rule-no-unknown": true,
+    "block-no-empty": true,
+    "color-no-invalid-hex": true,
+    "declaration-block-no-duplicate-properties": [
+      true,
+      {
+        ignore: [
+          "consecutive-duplicates",
+          "consecutive-duplicates-with-different-values",
+        ],
+      },
+    ],
+    "declaration-block-no-shorthand-property-overrides": true,
+    "font-family-no-duplicate-names": true,
+    "function-calc-no-unspaced-operator": true,
+    "property-no-unknown": [
+      true,
+      {
+        ignoreProperties: ["text-wrap"],
+      },
+    ],
+    "selector-anb-no-unmatchable": true,
+    "string-no-newline": true,
+    "unit-no-unknown": true,
+  },
+};

--- a/CSS_GUARDRAILS.md
+++ b/CSS_GUARDRAILS.md
@@ -1,0 +1,42 @@
+# CSS Guardrails (Stylelint)
+
+## Purpose
+
+This project uses Stylelint as a CSS guardrail to catch syntax and maintainability issues early in PRs and pushes.
+
+## Local command
+
+```bash
+npm run lint:css
+```
+
+The command lints:
+
+- `assets/css/**/*.css`
+- `style.css`
+
+## CI integration
+
+The `PR Tests` workflow includes a dedicated `css-guardrails` job that runs the same command on:
+
+- `push`
+- `pull_request`
+
+## Enforced baseline rules
+
+The Stylelint config (`.stylelintrc.cjs`) checks for:
+
+- unknown at-rules and properties
+- invalid hex colors and unknown units
+- duplicate declarations
+- shorthand-overridden longhand collisions
+- unspaced `calc()` operators
+- duplicate font-family names
+
+Stylelint output includes file path, line/column, and rule name to keep fixes actionable.
+
+## Legacy exceptions
+
+A small set of known legacy files is temporarily excluded from selected maintainability rules
+(`declaration-block-no-duplicate-properties` and specific shorthand-override cases).
+This keeps CI green while still enforcing the rules for newly touched/cleaner files.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Then open `http://127.0.0.1:4173/index.html`.
 
 ```bash
 npm run lint
+npm run lint:css
 npm run lint:jsdoc
 npm run lint:file-size
 npm run a11y:audit
@@ -44,6 +45,7 @@ npm run a11y:report
 - GitHub issue/PR/project/deploy automation: [GITHUB_AUTOMATION.md](./GITHUB_AUTOMATION.md)
 - Accessibility checks: [ACCESSIBILITY_CHECKS.md](./ACCESSIBILITY_CHECKS.md)
 - File-size guardrails: [FILE_SIZE_GUARDRAILS.md](./FILE_SIZE_GUARDRAILS.md)
+- CSS guardrails (Stylelint): [CSS_GUARDRAILS.md](./CSS_GUARDRAILS.md)
 - JSDoc guardrails: [JSDOC_GUARDRAILS.md](./JSDOC_GUARDRAILS.md)
 - UI tokens and breakpoints: [UI_TOKENS.md](./UI_TOKENS.md)
 - Secure rendering / XSS rules: [SECURITY_RENDERING.md](./SECURITY_RENDERING.md)

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
     "lint:jsdoc": "node scripts/check_jsdoc_coverage.cjs",
     "lint:jsdoc:update-baseline": "node scripts/check_jsdoc_coverage.cjs --update-baseline",
     "lint:file-size": "node scripts/check_file_size_guardrail.cjs",
+    "lint:css": "npx --yes stylelint@16.24.0 \"assets/css/**/*.css\" \"style.css\"",
     "lint:templates": "node scripts/check_duplicate_template_attributes.cjs",
     "lint:inline-events": "node scripts/check_inline_event_handlers.cjs",
     "lint:ui-tokens": "node scripts/check_ui_tokens_alignment.cjs",
-    "lint": "npm run lint:templates && npm run lint:inline-events && npm run lint:ui-tokens && npm run lint:file-size && npm run lint:jsdoc && npm run lint:js",
+    "lint": "npm run lint:templates && npm run lint:inline-events && npm run lint:ui-tokens && npm run lint:css && npm run lint:file-size && npm run lint:jsdoc && npm run lint:js",
     "a11y:ci": "npx --yes @lhci/cli autorun --config=./lighthouserc.cjs",
     "a11y:report": "node scripts/summarize_lighthouse_accessibility.cjs",
     "a11y:audit": "node scripts/check_accessibility_baseline.cjs"


### PR DESCRIPTION
## Summary
This PR introduces a dedicated CSS lint guardrail with Stylelint and integrates it into CI for push and pull_request events.

## Why
Current guardrails cover JS, templates, token alignment, file-size, and accessibility, but CSS syntax/maintainability checks were missing.  
This change adds an explicit CSS quality baseline and actionable CI feedback.

## Changes
- Added Stylelint configuration:
  - `.stylelintrc.cjs`
- Added local lint command:
  - `npm run lint:css`
- Included CSS lint in the global lint chain:
  - `npm run lint`
- Added CI job in `PR Tests` workflow:
  - `css-guardrails` running `npm run lint:css`
- Added documentation:
  - `CSS_GUARDRAILS.md`
  - README updates for command + docs index link

## Rule baseline
The config enforces key syntax/maintainability checks (unknown properties/at-rules, invalid units/colors, calc spacing, etc.).  
A small scoped legacy exception list is used for known historical files so CI can be introduced without breaking existing unrelated CSS debt.

## Validation
- `npm run lint:css` ✅
- `npm run lint:js` ✅
- `npm run lint:ui-tokens` ✅

Closes #125
