### PR TITLE
refactor(ui): replace rigid auth/help/legal widths with fluid constraints

### DIFF
--- a/assets/css/help.css
+++ b/assets/css/help.css
@@ -1,5 +1,7 @@
 .help-page {
-  margin: 0 var(--ui-page-inline);
+  width: min(100%, 1080px);
+  margin: 0 auto;
+  padding-inline: var(--ui-page-inline);
 }
 
 .help-page-header {
@@ -18,7 +20,7 @@
 
 .help-page-back-button img {
   display: block;
-  width: 40px;
+  width: clamp(32px, 6vw, 40px);
 }
 
 h1 {
@@ -83,11 +85,12 @@ h2 {
 
 @media screen and (max-width: 500px) {
   .help-page {
-    margin: 0 var(--ui-page-inline-mobile);
+    width: 100%;
+    padding-inline: var(--ui-page-inline-mobile);
   }
 
   .help-page-back-button img {
-    width: 32px;
+    width: clamp(28px, 8vw, 32px);
   }
 
   h2 {

--- a/assets/css/legalNotice.css
+++ b/assets/css/legalNotice.css
@@ -1,5 +1,7 @@
 .legal_notice-wrapper {
-  margin: 76px var(--ui-page-inline);
+  width: min(100%, 1080px);
+  margin: 76px auto;
+  padding-inline: var(--ui-page-inline);
 }
 
 h1 {
@@ -42,7 +44,7 @@ h3 {
 
 .h1LegalNoticeBackButton img {
   display: block;
-  width: 40px;
+  width: clamp(32px, 6vw, 40px);
   margin-bottom: 42px;
 }
 
@@ -72,7 +74,7 @@ a:not(.active):hover {
 .navigation-container {
   display: flex;
   flex-direction: column;
-  width: 232px;
+  width: min(100%, 232px);
   max-width: 232px;
 }
 
@@ -90,7 +92,7 @@ a:not(.active):hover {
   display: flex;
   align-items: center;
   height: 40px;
-  width: 186px;
+  width: min(100%, 186px);
   padding: var(--ui-space-xs) 30px;
   border-radius: 8px;
   gap: var(--ui-space-xs);
@@ -116,13 +118,14 @@ a:not(.active):hover {
 
 @media (max-width: 801px) {
   .legal_notice-wrapper {
-    margin: 36px var(--ui-page-inline-mobile);
+    margin: 36px auto;
+    padding-inline: var(--ui-page-inline-mobile);
   }
 }
 
 @media (max-width: 500px) {
   .h1LegalNoticeBackButton img {
-    width: 32px;
+    width: clamp(28px, 8vw, 32px);
     margin-bottom: 24px;
   }
 }

--- a/assets/css/login.css
+++ b/assets/css/login.css
@@ -4,7 +4,13 @@
   /* font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; */
   font-family: "Open Sans", sans-serif;
-  max-width: 1440px;
+}
+
+:root {
+  --auth-form-max-width: 422px;
+  --auth-card-max-width: 652px;
+  --auth-logo-size: clamp(48px, 9vw, 64px);
+  --auth-input-padding-inline: clamp(12px, 3vw, 21px);
 }
 
 .loginMainContainer {
@@ -62,7 +68,8 @@
   align-items: center;
   border: 1px solid lightgrey;
   border-radius: 30px;
-  padding: 48px 115px;
+  width: min(100%, var(--auth-card-max-width));
+  padding: clamp(24px, 6vw, 48px) clamp(16px, 8vw, 115px);
   gap: 39px;
   box-shadow: 0px 0px 10px 3px rgba(0, 0, 0, 0.08);
 }
@@ -101,10 +108,10 @@
   display: flex;
   justify-content: space-between;
   align-items: self-end;
-  width: 422px;
+  width: min(100%, var(--auth-form-max-width));
   border-bottom: 1px solid #d1d1d1;
   /* margin-bottom: 24px; */
-  padding: 12px 21px;
+  padding: 12px var(--auth-input-padding-inline);
   gap: 34px;
 }
 
@@ -261,7 +268,7 @@ input[type="password"]:focus {
 
 .goal img {
   height: 78px;
-  width: 64px;
+  width: var(--auth-logo-size);
   transition: all 500ms ease-in-out;
 }
 
@@ -281,7 +288,7 @@ input[type="password"]:focus {
 /*/////////////////////////MOBILE///////////////////////////*/
 @media (max-width: 970px) {
   .joinLogoBlue img {
-    width: 64px;
+    width: var(--auth-logo-size);
     height: 78px;
   }
 }
@@ -325,7 +332,7 @@ input[type="password"]:focus {
   }
 
   .joinLogoBlue img {
-    width: 64px;
+    width: var(--auth-logo-size);
     height: 78px;
   }
 
@@ -366,7 +373,7 @@ input[type="password"]:focus {
   }
 
   .joinLogoBlue img {
-    width: 64px;
+    width: var(--auth-logo-size);
     height: 78px;
   }
 
@@ -395,7 +402,7 @@ input[type="password"]:focus {
   }
 
   .loginInputField {
-    width: 250px;
+    width: min(100%, var(--auth-form-max-width));
   }
 
   .loginButtonsBox {
@@ -433,7 +440,7 @@ input[type="password"]:focus {
     font-size: 16px;
     font-weight: 400;
     padding-top: 12.5px;
-    width: 160px;
+    width: 100%;
   }
 
   .horizontalH1Underline {
@@ -445,7 +452,7 @@ input[type="password"]:focus {
   }
 
   .loginButtons {
-    width: 142px;
+    width: clamp(132px, 38vw, 180px);
     height: 48px;
     font-size: 18px;
     font-weight: 400;

--- a/assets/css/privacy.css
+++ b/assets/css/privacy.css
@@ -1,5 +1,7 @@
 .privacy-wrapper {
-  margin: 76px var(--ui-page-inline);
+  width: min(100%, 1080px);
+  margin: 76px auto;
+  padding-inline: var(--ui-page-inline);
 }
 
 h1 {
@@ -52,13 +54,14 @@ p {
 
 .h1PrivacyBackButton img {
   display: block;
-  width: 40px;
+  width: clamp(32px, 6vw, 40px);
   margin-bottom: 42px;
 }
 
 @media (max-width: 900px) {
   .privacy-wrapper {
-    margin: 36px var(--ui-page-inline-mobile);
+    margin: 36px auto;
+    padding-inline: var(--ui-page-inline-mobile);
   }
 
   h1 {
@@ -90,15 +93,9 @@ p {
   }
 }
 
-@media (max-width: 801px) {
-  .privacy-wrapper {
-    margin: 36px var(--ui-page-inline-mobile);
-  }
-}
-
 @media (max-width: 500px) {
   .h1PrivacyBackButton img {
-    width: 32px;
+    width: clamp(28px, 8vw, 32px);
     margin-bottom: 24px;
   }
 }

--- a/assets/css/signUp.css
+++ b/assets/css/signUp.css
@@ -1,6 +1,13 @@
-.main {
+:root {
+  --signup-box-max-width: 600px;
+  --signup-field-max-width: 422px;
+}
+
+.main .signUpMainContainer {
   position: relative;
   height: 100vh;
+  max-width: none;
+  width: 100vw;
   background-color: var(--clr-main);
 }
 
@@ -9,6 +16,11 @@
   top: 80px;
   left: 77px;
   z-index: 1;
+}
+
+.main.signup-active {
+  max-width: none !important;
+  width: 100% !important;
 }
 
 .signUpMainContainer {
@@ -20,6 +32,11 @@
   justify-content: center;
   align-items: center;
   height: 100vh;
+}
+
+.signUpMainContainer {
+  max-width: none;
+  width: 100%;
 }
 
 .signUp-page {
@@ -35,8 +52,8 @@
   background-color: #fff;
   border: 1px solid grey;
   border-radius: 30px;
-  width: 600px;
-  padding: 48px 115px;
+  width: min(100%, var(--signup-box-max-width));
+  padding: clamp(24px, 5vw, 48px) clamp(16px, 8vw, 115px);
   gap: 39px;
   box-shadow: 0px 0px 10px 3px rgba(0, 0, 0, 0.08);
   position: relative;
@@ -56,11 +73,12 @@
 }
 
 .input-wrapper {
-    margin-bottom: 10px; 
+  margin-bottom: 10px;
+  width: min(100%, var(--signup-field-max-width));
 }
 
 .input-wrapper {
-  margin-bottom: 10px; 
+  margin-bottom: 10px;
 }
 
 .error-message {
@@ -115,7 +133,7 @@ button#registerBtn:disabled {
   display: flex;
   justify-content: space-between;
   align-items: self-end;
-  width: 422px;
+  width: min(100%, var(--signup-field-max-width));
   border-bottom: 1px solid #d1d1d1;
   gap: 10px;
 }
@@ -125,7 +143,7 @@ button#registerBtn:disabled {
   justify-content: space-between;
   border-bottom: 1px solid #d1d1d1;
   padding: 12px 21px;
-  width: 140%;
+  width: 100%;
 }
 
 input::placeholder {
@@ -137,6 +155,7 @@ input::placeholder {
   gap: 32px;
   justify-content: center;
   align-items: center;
+  width: 100%;
 }
 
 input:-webkit-autofill,
@@ -150,7 +169,7 @@ input:-webkit-autofill:active {
   display: flex;
   justify-content: space-between;
   align-items: self-end;
-  width: 422px;
+  width: min(100%, var(--signup-field-max-width));
   border-bottom: 1px solid #d1d1d1;
   gap: 10px;
 }
@@ -232,7 +251,8 @@ a {
   gap: 16px;
 }
 
-.signUpFooter > div {
+.signUpFooter > div,
+.signUpFooter > button {
   cursor: pointer;
 }
 
@@ -241,6 +261,9 @@ a {
   font-size: 16px;
   font-weight: 400;
   color: #fff;
+  border: none;
+  background: transparent;
+  padding: 0;
 }
 
 .privacyPolicySignUp:hover,
@@ -366,21 +389,22 @@ a {
 
   .signUpEmailBox,
   .signUpNameBox {
-    width: 364px;
+    width: min(100%, var(--signup-field-max-width));
   }
 
   .signUpPasswordBox {
-    width: 364px;
+    width: min(100%, var(--signup-field-max-width));
   }
 
   .signUp-box {
-    width: 482px;
+    --signup-box-max-width: 482px;
+    --signup-field-max-width: 364px;
   }
 }
 /*///////////////////////////////////////////////media 550///////////////////////*/
 @media (max-width: 550px) {
   .signUp-box {
-    width: 402px;
+    --signup-box-max-width: 402px;
   }
 }
 
@@ -396,7 +420,7 @@ a {
   }
 
   .signUp-box {
-    width: 290px;
+    --signup-box-max-width: 290px;
     z-index: 1;
   }
 
@@ -417,14 +441,14 @@ a {
 
   .signUpEmailBox,
   .signUpNameBox {
-    width: 250px;
+    width: min(100%, 250px);
     padding: 0;
     gap: 0px;
   }
 
   .signUpPasswordBox {
     justify-content: center;
-    width: 250px;
+    width: min(100%, 250px);
     padding: 0;
     gap: 0px;
   }


### PR DESCRIPTION
## Summary
- replace rigid fixed widths with fluid constraints across auth/help/legal/privacy pages
- migrate key container/input sizing to `min()`, `max-width`, and `clamp()` patterns
- keep visual design intent while reducing per-breakpoint hardcoded overrides

## Changes
- update auth layout sizing in `assets/css/login.css` and `assets/css/signUp.css`
- convert help/legal/privacy wrappers to centered fluid containers in:
  - `assets/css/help.css`
  - `assets/css/legalNotice.css`
  - `assets/css/privacy.css`
- reduce brittle width overrides and align behavior with existing responsive token strategy

## Validation
- `npm run lint:ui-tokens`
- `npm run lint:js`

Closes #126
