### PR TITLE
perf(bootstrap): switch core pages to defer-safe script loading

### DIFF
--- a/addTask.html
+++ b/addTask.html
@@ -21,46 +21,46 @@
   <link rel="stylesheet" href="./assets/css/mobile-hardening.css">
 
   <!-- Scripts -->
-  <script src="./js/runtime-fallbacks.js"></script>
-  <script src="./js/ui-event-actions.js"></script>
-    <script src="./js/ui-event-delegation.js"></script>
-  <script src="./js/responsive-navigation.js"></script>
-  <script src="./js/cookiebot-bootstrap.js"></script>
-  <script src="script.js"></script>
-  <script src="js/helper_dom.js"></script>
-  <script src="js/helper_sanitize.js"></script>
-  <script src="js/helper_focus.js"></script>
-  <script src="js/helper.js"></script>
-  <script src="js/config.js"></script>
-  <script src="js/storage_compat_fallbacks.js?v=20260226-2"></script>
-  <script src="js/storage_error_policy.js?v=20260226-1"></script>
-  <script src="js/storage_transport.js?v=20260226-1"></script>
-  <script src="js/storage_firebase_adapter.js?v=20260226-1"></script>
-  <script src="js/storage_runtime.js?v=20260226-1"></script>
-  <script src="js/storage.js?v=20260226-2"></script>
-  <script src="js/auth.js"></script>
-  <script src="js/addTask_dropdown.js"></script>
-  <script src="js/addTask_keyboard.js"></script>
-  <script src="js/addTask_form_domain.js"></script>
-  <script src="js/addTask_ui.js"></script>
-  <script src="js/addTask.js"></script>
-  <script src="js/addTask_task_storage.js"></script>
-  <script src="js/addTask_tasks.js"></script>
-  <script src="js/contacts.js"></script>
-  <script src="js/contacts_view.js"></script>
-  <script src="js/board.js"></script>
-  <script src="js/board_rendering.js"></script>
-  <script src="js/board_state.js"></script>
-  <script src="js/board_media.js"></script>
-  <script src="js/board_drag_and_drop.js"></script>
-  <script src="js/board_popups.js"></script>
-  <script src="./assets/templates/templates_shared.js"></script>
-  <script src="./assets/templates/templates_navigation_auth.js"></script>
-  <script src="./assets/templates/templates_board.js"></script>
-  <script src="./assets/templates/templates_addtask.js"></script>
-  <script src="js/filepicker_media.js"></script>
-  <script src="js/filepicker.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/viewerjs/1.11.7/viewer.min.js" 
+  <script defer src="./js/runtime-fallbacks.js"></script>
+  <script defer src="./js/ui-event-actions.js"></script>
+    <script defer src="./js/ui-event-delegation.js"></script>
+  <script defer src="./js/responsive-navigation.js"></script>
+  <script defer src="./js/cookiebot-bootstrap.js"></script>
+  <script defer src="script.js"></script>
+  <script defer src="js/helper_dom.js"></script>
+  <script defer src="js/helper_sanitize.js"></script>
+  <script defer src="js/helper_focus.js"></script>
+  <script defer src="js/helper.js"></script>
+  <script defer src="js/config.js"></script>
+  <script defer src="js/storage_compat_fallbacks.js?v=20260226-2"></script>
+  <script defer src="js/storage_error_policy.js?v=20260226-1"></script>
+  <script defer src="js/storage_transport.js?v=20260226-1"></script>
+  <script defer src="js/storage_firebase_adapter.js?v=20260226-1"></script>
+  <script defer src="js/storage_runtime.js?v=20260226-1"></script>
+  <script defer src="js/storage.js?v=20260226-2"></script>
+  <script defer src="js/auth.js"></script>
+  <script defer src="js/addTask_dropdown.js"></script>
+  <script defer src="js/addTask_keyboard.js"></script>
+  <script defer src="js/addTask_form_domain.js"></script>
+  <script defer src="js/addTask_ui.js"></script>
+  <script defer src="js/addTask.js"></script>
+  <script defer src="js/addTask_task_storage.js"></script>
+  <script defer src="js/addTask_tasks.js"></script>
+  <script defer src="js/contacts.js"></script>
+  <script defer src="js/contacts_view.js"></script>
+  <script defer src="js/board.js"></script>
+  <script defer src="js/board_rendering.js"></script>
+  <script defer src="js/board_state.js"></script>
+  <script defer src="js/board_media.js"></script>
+  <script defer src="js/board_drag_and_drop.js"></script>
+  <script defer src="js/board_popups.js"></script>
+  <script defer src="./assets/templates/templates_shared.js"></script>
+  <script defer src="./assets/templates/templates_navigation_auth.js"></script>
+  <script defer src="./assets/templates/templates_board.js"></script>
+  <script defer src="./assets/templates/templates_addtask.js"></script>
+  <script defer src="js/filepicker_media.js"></script>
+  <script defer src="js/filepicker.js"></script>
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/viewerjs/1.11.7/viewer.min.js" 
           integrity="sha512-lZD0JiwhtP4UkFD1mc96NiTZ14L7MjyX5Khk8PMxJszXMLvu7kjq1sp4bb0tcL6MY+/4sIuiUxubOqoueHrW4w==" 
           crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 

--- a/board.html
+++ b/board.html
@@ -15,50 +15,50 @@
     <link rel="stylesheet" href="./assets/css/addTask.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/viewerjs/1.11.7/viewer.css" integrity="sha512-9NawOLzuLE2GD22PJ6IPWXEjPalb/FpdH1qMpgXdaDM+0OfxEV75ZCle6KhZi0vM6ZWvMrNnIZv6YnsL+keVmA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="./assets/css/viewer-overrides.css">
-    <script src="./js/runtime-fallbacks.js"></script>
-    <script src="./js/ui-event-actions.js"></script>
-    <script src="./js/ui-event-delegation.js"></script>
-    <script src="./js/responsive-navigation.js"></script>
-    <script src="./js/cookiebot-bootstrap.js"></script>
-    <script src="script.js"></script>
+    <script defer src="./js/runtime-fallbacks.js"></script>
+    <script defer src="./js/ui-event-actions.js"></script>
+    <script defer src="./js/ui-event-delegation.js"></script>
+    <script defer src="./js/responsive-navigation.js"></script>
+    <script defer src="./js/cookiebot-bootstrap.js"></script>
+    <script defer src="script.js"></script>
 
     <link rel="stylesheet" href="./assets/css/board.css">
     <link rel="stylesheet" href="./assets/css/mobile-hardening.css">
-    <script src="./js/filepicker_media.js"></script>
-    <script src="./js/filepicker.js"></script>
-    <script src="./js/board.js"></script>
-    <script src="./js/board_rendering.js"></script>
-    <script src="./js/board_state.js"></script>
-    <script src="./js/board_media.js"></script>
-    <script src="./js/board_popups.js"></script>
-    <script src="./js/board_drag_and_drop.js"></script>
-    <script src="./js/contacts.js"></script>
-    <script src="./js/contacts_view.js"></script>
-    <script src="./js/addTask_dropdown.js"></script>
-    <script src="./js/addTask_keyboard.js"></script>
-    <script src="./js/addTask_form_domain.js"></script>
-    <script src="./js/addTask_ui.js"></script>
-    <script src="./js/addTask.js"></script>
-    <script src="./js/addTask_task_storage.js"></script>
-    <script src="./js/addTask_tasks.js"></script>
-    <script src="./js/config.js"></script>
-    <script src="./js/storage_compat_fallbacks.js?v=20260226-2"></script>
-    <script src="./js/storage_error_policy.js?v=20260226-1"></script>
-    <script src="./js/storage_transport.js?v=20260226-1"></script>
-    <script src="./js/storage_firebase_adapter.js?v=20260226-1"></script>
-    <script src="./js/storage_runtime.js?v=20260226-1"></script>
-    <script src="./js/storage.js?v=20260226-2"></script>
-    <script src="./js/auth.js"></script>
-    <script src="./js/helper_dom.js"></script>
-    <script src="./js/helper_sanitize.js"></script>
-    <script src="./js/helper_focus.js"></script>
-    <script src="./js/helper.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/viewerjs/1.11.7/viewer.min.js" integrity="sha512-lZD0JiwhtP4UkFD1mc96NiTZ14L7MjyX5Khk8PMxJszXMLvu7kjq1sp4bb0tcL6MY+/4sIuiUxubOqoueHrW4w==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script defer src="./js/filepicker_media.js"></script>
+    <script defer src="./js/filepicker.js"></script>
+    <script defer src="./js/board.js"></script>
+    <script defer src="./js/board_rendering.js"></script>
+    <script defer src="./js/board_state.js"></script>
+    <script defer src="./js/board_media.js"></script>
+    <script defer src="./js/board_popups.js"></script>
+    <script defer src="./js/board_drag_and_drop.js"></script>
+    <script defer src="./js/contacts.js"></script>
+    <script defer src="./js/contacts_view.js"></script>
+    <script defer src="./js/addTask_dropdown.js"></script>
+    <script defer src="./js/addTask_keyboard.js"></script>
+    <script defer src="./js/addTask_form_domain.js"></script>
+    <script defer src="./js/addTask_ui.js"></script>
+    <script defer src="./js/addTask.js"></script>
+    <script defer src="./js/addTask_task_storage.js"></script>
+    <script defer src="./js/addTask_tasks.js"></script>
+    <script defer src="./js/config.js"></script>
+    <script defer src="./js/storage_compat_fallbacks.js?v=20260226-2"></script>
+    <script defer src="./js/storage_error_policy.js?v=20260226-1"></script>
+    <script defer src="./js/storage_transport.js?v=20260226-1"></script>
+    <script defer src="./js/storage_firebase_adapter.js?v=20260226-1"></script>
+    <script defer src="./js/storage_runtime.js?v=20260226-1"></script>
+    <script defer src="./js/storage.js?v=20260226-2"></script>
+    <script defer src="./js/auth.js"></script>
+    <script defer src="./js/helper_dom.js"></script>
+    <script defer src="./js/helper_sanitize.js"></script>
+    <script defer src="./js/helper_focus.js"></script>
+    <script defer src="./js/helper.js"></script>
+    <script defer src="https://cdnjs.cloudflare.com/ajax/libs/viewerjs/1.11.7/viewer.min.js" integrity="sha512-lZD0JiwhtP4UkFD1mc96NiTZ14L7MjyX5Khk8PMxJszXMLvu7kjq1sp4bb0tcL6MY+/4sIuiUxubOqoueHrW4w==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
-    <script src="./assets/templates/templates_shared.js"></script>
-    <script src="./assets/templates/templates_navigation_auth.js"></script>
-    <script src="./assets/templates/templates_board.js"></script>
-    <script src="./assets/templates/templates_addtask.js"></script>
+    <script defer src="./assets/templates/templates_shared.js"></script>
+    <script defer src="./assets/templates/templates_navigation_auth.js"></script>
+    <script defer src="./assets/templates/templates_board.js"></script>
+    <script defer src="./assets/templates/templates_addtask.js"></script>
 
     <title>Join - AddTask</title>
 </head>

--- a/contacts.html
+++ b/contacts.html
@@ -15,41 +15,41 @@
 
     <link rel="stylesheet" href="./assets/css/board.css">
     <link rel="stylesheet" href="./assets/css/mobile-hardening.css">
-    <script src="./js/runtime-fallbacks.js"></script>
-    <script src="./js/ui-event-actions.js"></script>
-    <script src="./js/ui-event-delegation.js"></script>
-    <script src="./js/responsive-navigation.js"></script>
-    <script src="./js/cookiebot-bootstrap.js"></script>
-    <script src="script.js"></script>
-    <script src="./js/config.js"></script>
-    <script src="./js/storage_compat_fallbacks.js?v=20260226-2"></script>
-    <script src="./js/storage_error_policy.js?v=20260226-1"></script>
-    <script src="./js/storage_transport.js?v=20260226-1"></script>
-    <script src="./js/storage_firebase_adapter.js?v=20260226-1"></script>
-    <script src="./js/storage_runtime.js?v=20260226-1"></script>
-    <script src="./js/storage.js?v=20260226-2"></script>
-    <script src="./js/auth.js"></script>
-    <script src="./js/helper_dom.js"></script>
-    <script src="./js/helper_sanitize.js"></script>
-    <script src="./js/helper_focus.js"></script>
-    <script src="./js/helper.js"></script>
-    <script src="./js/addTask_dropdown.js"></script>
-    <script src="./js/addTask_keyboard.js"></script>
-    <script src="./js/addTask_form_domain.js"></script>
-    <script src="./js/addTask_ui.js"></script>
-    <script src="./js/addTask.js"></script>
-    <script src="./js/contacts_render.js"></script>
-    <script src="./js/contacts.js"></script>
-    <script src="./js/contacts_view.js"></script>
-    <script src="./js/contact_list.js"></script>
-    <script src="./js/contact_popups_validation.js"></script>
-    <script src="./js/contact_popups_overlay.js"></script>
-    <script src="./js/contact_popups_mutations.js"></script>
-    <script src="./js/contact_popups.js"></script>
-    <script src="./assets/templates/templates_shared.js"></script>
-    <script src="./assets/templates/templates_navigation_auth.js"></script>
-    <script src="./assets/templates/templates_board.js"></script>
-    <script src="./assets/templates/templates_addtask.js"></script>
+    <script defer src="./js/runtime-fallbacks.js"></script>
+    <script defer src="./js/ui-event-actions.js"></script>
+    <script defer src="./js/ui-event-delegation.js"></script>
+    <script defer src="./js/responsive-navigation.js"></script>
+    <script defer src="./js/cookiebot-bootstrap.js"></script>
+    <script defer src="script.js"></script>
+    <script defer src="./js/config.js"></script>
+    <script defer src="./js/storage_compat_fallbacks.js?v=20260226-2"></script>
+    <script defer src="./js/storage_error_policy.js?v=20260226-1"></script>
+    <script defer src="./js/storage_transport.js?v=20260226-1"></script>
+    <script defer src="./js/storage_firebase_adapter.js?v=20260226-1"></script>
+    <script defer src="./js/storage_runtime.js?v=20260226-1"></script>
+    <script defer src="./js/storage.js?v=20260226-2"></script>
+    <script defer src="./js/auth.js"></script>
+    <script defer src="./js/helper_dom.js"></script>
+    <script defer src="./js/helper_sanitize.js"></script>
+    <script defer src="./js/helper_focus.js"></script>
+    <script defer src="./js/helper.js"></script>
+    <script defer src="./js/addTask_dropdown.js"></script>
+    <script defer src="./js/addTask_keyboard.js"></script>
+    <script defer src="./js/addTask_form_domain.js"></script>
+    <script defer src="./js/addTask_ui.js"></script>
+    <script defer src="./js/addTask.js"></script>
+    <script defer src="./js/contacts_render.js"></script>
+    <script defer src="./js/contacts.js"></script>
+    <script defer src="./js/contacts_view.js"></script>
+    <script defer src="./js/contact_list.js"></script>
+    <script defer src="./js/contact_popups_validation.js"></script>
+    <script defer src="./js/contact_popups_overlay.js"></script>
+    <script defer src="./js/contact_popups_mutations.js"></script>
+    <script defer src="./js/contact_popups.js"></script>
+    <script defer src="./assets/templates/templates_shared.js"></script>
+    <script defer src="./assets/templates/templates_navigation_auth.js"></script>
+    <script defer src="./assets/templates/templates_board.js"></script>
+    <script defer src="./assets/templates/templates_addtask.js"></script>
 
     <title>Join - Contacts</title>
 </head>

--- a/help.html
+++ b/help.html
@@ -13,20 +13,20 @@
     <link rel="stylesheet" href="assets/css/navigation.css" />
     <link rel="stylesheet" href="./assets/css/help.css">
     
-    <script src="./js/runtime-fallbacks.js"></script>
-    <script src="./js/ui-event-actions.js"></script>
-    <script src="./js/ui-event-delegation.js"></script>
-    <script src="./js/responsive-navigation.js"></script>
-    <script src="./js/cookiebot-bootstrap.js"></script>
-    <script src="script.js"></script>
-    <script src="./js/config.js"></script>
-    <script src="./js/help.js"></script>
-    <script src="./js/contacts.js"></script>
-    <script src="./js/contacts_view.js"></script>
-    <script src="./assets/templates/templates_shared.js"></script>
-    <script src="./assets/templates/templates_navigation_auth.js"></script>
-    <script src="./assets/templates/templates_board.js"></script>
-    <script src="./assets/templates/templates_addtask.js"></script>
+    <script defer src="./js/runtime-fallbacks.js"></script>
+    <script defer src="./js/ui-event-actions.js"></script>
+    <script defer src="./js/ui-event-delegation.js"></script>
+    <script defer src="./js/responsive-navigation.js"></script>
+    <script defer src="./js/cookiebot-bootstrap.js"></script>
+    <script defer src="script.js"></script>
+    <script defer src="./js/config.js"></script>
+    <script defer src="./js/help.js"></script>
+    <script defer src="./js/contacts.js"></script>
+    <script defer src="./js/contacts_view.js"></script>
+    <script defer src="./assets/templates/templates_shared.js"></script>
+    <script defer src="./assets/templates/templates_navigation_auth.js"></script>
+    <script defer src="./assets/templates/templates_board.js"></script>
+    <script defer src="./assets/templates/templates_addtask.js"></script>
 
     <title>Join - Help</title>
 </head>

--- a/index.html
+++ b/index.html
@@ -14,21 +14,21 @@
     <link rel="stylesheet" href="./assets/css/signUp.css">
     <link rel="stylesheet" href="./assets/css/login.css">
 
-    <script src="./js/runtime-fallbacks.js"></script>
-    <script src="./js/ui-event-actions.js"></script>
-    <script src="./js/ui-event-delegation.js"></script>
-    <script src="./js/responsive-navigation.js"></script>
-    <script src="./js/cookiebot-bootstrap.js"></script>
-    <script src="script.js"></script>
-    <script src="./js/config.js"></script>
-    <script src="./js/storage_compat_fallbacks.js?v=20260226-2"></script>
-    <script src="./js/storage_error_policy.js?v=20260226-1"></script>
-    <script src="./js/storage_transport.js?v=20260226-1"></script>
-    <script src="./js/storage_firebase_adapter.js?v=20260226-1"></script>
-    <script src="./js/storage_runtime.js?v=20260226-1"></script>
-    <script src="./js/storage.js?v=20260226-2"></script>
-    <script src="./js/auth.js"></script>
-    <script src="./js/login.js"></script>
+    <script defer src="./js/runtime-fallbacks.js"></script>
+    <script defer src="./js/ui-event-actions.js"></script>
+    <script defer src="./js/ui-event-delegation.js"></script>
+    <script defer src="./js/responsive-navigation.js"></script>
+    <script defer src="./js/cookiebot-bootstrap.js"></script>
+    <script defer src="script.js"></script>
+    <script defer src="./js/config.js"></script>
+    <script defer src="./js/storage_compat_fallbacks.js?v=20260226-2"></script>
+    <script defer src="./js/storage_error_policy.js?v=20260226-1"></script>
+    <script defer src="./js/storage_transport.js?v=20260226-1"></script>
+    <script defer src="./js/storage_firebase_adapter.js?v=20260226-1"></script>
+    <script defer src="./js/storage_runtime.js?v=20260226-1"></script>
+    <script defer src="./js/storage.js?v=20260226-2"></script>
+    <script defer src="./js/auth.js"></script>
+    <script defer src="./js/login.js"></script>
 
     <title>Join - Login</title>
 </head>

--- a/legal_notice.html
+++ b/legal_notice.html
@@ -18,18 +18,18 @@
 
     <link rel="shortcut icon" href="./assets/img/favicon.png" type="image/png">
 
-    <script src="./js/runtime-fallbacks.js"></script>
-    <script src="./js/ui-event-actions.js"></script>
-    <script src="./js/ui-event-delegation.js"></script>
-    <script src="./js/responsive-navigation.js"></script>
-    <script src="./js/cookiebot-bootstrap.js"></script>
-    <script src="script.js"></script>
-    <script src="./js/config.js"></script>
-    <script src="./assets/templates/templates_shared.js"></script>
-    <script src="./assets/templates/templates_navigation_auth.js"></script>
-    <script src="./assets/templates/templates_board.js"></script>
-    <script src="./assets/templates/templates_addtask.js"></script>
-    <script src="./js/privacy_and_legal.js"></script>
+    <script defer src="./js/runtime-fallbacks.js"></script>
+    <script defer src="./js/ui-event-actions.js"></script>
+    <script defer src="./js/ui-event-delegation.js"></script>
+    <script defer src="./js/responsive-navigation.js"></script>
+    <script defer src="./js/cookiebot-bootstrap.js"></script>
+    <script defer src="script.js"></script>
+    <script defer src="./js/config.js"></script>
+    <script defer src="./assets/templates/templates_shared.js"></script>
+    <script defer src="./assets/templates/templates_navigation_auth.js"></script>
+    <script defer src="./assets/templates/templates_board.js"></script>
+    <script defer src="./assets/templates/templates_addtask.js"></script>
+    <script defer src="./js/privacy_and_legal.js"></script>
 
     <title>Join - Legal Notice</title>
 </head>

--- a/legal_notice_external.html
+++ b/legal_notice_external.html
@@ -20,18 +20,18 @@
     
     <link rel="shortcut icon" href="./assets/img/favicon.png" type="image/png">
     
-    <script src="./js/runtime-fallbacks.js"></script>
-    <script src="./js/ui-event-actions.js"></script>
-    <script src="./js/ui-event-delegation.js"></script>
-    <script src="./js/responsive-navigation.js"></script>
-    <script src="./js/cookiebot-bootstrap.js"></script>
-    <script src="script.js"></script>
-    <script src="./js/config.js"></script>
-    <script src="./assets/templates/templates_shared.js"></script>
-    <script src="./assets/templates/templates_navigation_auth.js"></script>
-    <script src="./assets/templates/templates_board.js"></script>
-    <script src="./assets/templates/templates_addtask.js"></script>
-    <script src="./js/privacy_and_legal.js"></script>
+    <script defer src="./js/runtime-fallbacks.js"></script>
+    <script defer src="./js/ui-event-actions.js"></script>
+    <script defer src="./js/ui-event-delegation.js"></script>
+    <script defer src="./js/responsive-navigation.js"></script>
+    <script defer src="./js/cookiebot-bootstrap.js"></script>
+    <script defer src="script.js"></script>
+    <script defer src="./js/config.js"></script>
+    <script defer src="./assets/templates/templates_shared.js"></script>
+    <script defer src="./assets/templates/templates_navigation_auth.js"></script>
+    <script defer src="./assets/templates/templates_board.js"></script>
+    <script defer src="./assets/templates/templates_addtask.js"></script>
+    <script defer src="./js/privacy_and_legal.js"></script>
 
     <title>Join - Legal Notice External</title>
 </head>

--- a/privacy.html
+++ b/privacy.html
@@ -15,18 +15,18 @@
 
     <link rel="shortcut icon" href="./assets/img/favicon.png" type="image/png">
 
-    <script src="./js/runtime-fallbacks.js"></script>
-    <script src="./js/ui-event-actions.js"></script>
-    <script src="./js/ui-event-delegation.js"></script>
-    <script src="./js/responsive-navigation.js"></script>
-    <script src="./js/cookiebot-bootstrap.js"></script>
-    <script src="script.js"></script>
-    <script src="./js/config.js"></script>
-    <script src="./assets/templates/templates_shared.js"></script>
-    <script src="./assets/templates/templates_navigation_auth.js"></script>
-    <script src="./assets/templates/templates_board.js"></script>
-    <script src="./assets/templates/templates_addtask.js"></script>
-    <script src="./js/privacy_and_legal.js"></script>
+    <script defer src="./js/runtime-fallbacks.js"></script>
+    <script defer src="./js/ui-event-actions.js"></script>
+    <script defer src="./js/ui-event-delegation.js"></script>
+    <script defer src="./js/responsive-navigation.js"></script>
+    <script defer src="./js/cookiebot-bootstrap.js"></script>
+    <script defer src="script.js"></script>
+    <script defer src="./js/config.js"></script>
+    <script defer src="./assets/templates/templates_shared.js"></script>
+    <script defer src="./assets/templates/templates_navigation_auth.js"></script>
+    <script defer src="./assets/templates/templates_board.js"></script>
+    <script defer src="./assets/templates/templates_addtask.js"></script>
+    <script defer src="./js/privacy_and_legal.js"></script>
 
     <title>Join - Privacy Policy</title>
 </head>

--- a/privacy_external.html
+++ b/privacy_external.html
@@ -16,18 +16,18 @@
     <link rel="stylesheet" href="assets/css/external.css">
     <link rel="shortcut icon" href="./assets/img/favicon.png" type="image/png">
     
-    <script src="./js/runtime-fallbacks.js"></script>
-    <script src="./js/ui-event-actions.js"></script>
-    <script src="./js/ui-event-delegation.js"></script>
-    <script src="./js/responsive-navigation.js"></script>
-    <script src="./js/cookiebot-bootstrap.js"></script>
-    <script src="script.js"></script>
-    <script src="./js/config.js"></script>
-    <script src="./assets/templates/templates_shared.js"></script>
-    <script src="./assets/templates/templates_navigation_auth.js"></script>
-    <script src="./assets/templates/templates_board.js"></script>
-    <script src="./assets/templates/templates_addtask.js"></script>
-    <script src="./js/privacy_and_legal.js"></script>
+    <script defer src="./js/runtime-fallbacks.js"></script>
+    <script defer src="./js/ui-event-actions.js"></script>
+    <script defer src="./js/ui-event-delegation.js"></script>
+    <script defer src="./js/responsive-navigation.js"></script>
+    <script defer src="./js/cookiebot-bootstrap.js"></script>
+    <script defer src="script.js"></script>
+    <script defer src="./js/config.js"></script>
+    <script defer src="./assets/templates/templates_shared.js"></script>
+    <script defer src="./assets/templates/templates_navigation_auth.js"></script>
+    <script defer src="./assets/templates/templates_board.js"></script>
+    <script defer src="./assets/templates/templates_addtask.js"></script>
+    <script defer src="./js/privacy_and_legal.js"></script>
     <title>Join - Privacy Policy External</title>
 </head>
 

--- a/signUp.html
+++ b/signUp.html
@@ -10,25 +10,25 @@
   <link rel="stylesheet" href="assets/css/header.css" />
   <link rel="stylesheet" href="assets/css/navigation.css" />
   <link rel="stylesheet" href="./assets/css/signUp.css">
-  <script src="./js/runtime-fallbacks.js"></script>
-  <script src="./js/ui-event-actions.js"></script>
-    <script src="./js/ui-event-delegation.js"></script>
-  <script src="./js/responsive-navigation.js"></script>
-  <script src="./js/cookiebot-bootstrap.js"></script>
-  <script src="script.js"></script>
-  <script src="./js/config.js"></script>
-  <script src="./js/storage_compat_fallbacks.js?v=20260226-2"></script>
-  <script src="./js/storage_error_policy.js?v=20260226-1"></script>
-  <script src="./js/storage_transport.js?v=20260226-1"></script>
-  <script src="./js/storage_firebase_adapter.js?v=20260226-1"></script>
-  <script src="./js/storage_runtime.js?v=20260226-1"></script>
-  <script src="./js/storage.js?v=20260226-2"></script>
-  <script src="./js/auth.js"></script>
-  <script src="./js/helper_dom.js"></script>
-  <script src="./js/helper_sanitize.js"></script>
-  <script src="./js/helper_focus.js"></script>
-  <script src="./js/signUp.js"></script>
-  <script src="./js/helper.js"></script>
+  <script defer src="./js/runtime-fallbacks.js"></script>
+  <script defer src="./js/ui-event-actions.js"></script>
+    <script defer src="./js/ui-event-delegation.js"></script>
+  <script defer src="./js/responsive-navigation.js"></script>
+  <script defer src="./js/cookiebot-bootstrap.js"></script>
+  <script defer src="script.js"></script>
+  <script defer src="./js/config.js"></script>
+  <script defer src="./js/storage_compat_fallbacks.js?v=20260226-2"></script>
+  <script defer src="./js/storage_error_policy.js?v=20260226-1"></script>
+  <script defer src="./js/storage_transport.js?v=20260226-1"></script>
+  <script defer src="./js/storage_firebase_adapter.js?v=20260226-1"></script>
+  <script defer src="./js/storage_runtime.js?v=20260226-1"></script>
+  <script defer src="./js/storage.js?v=20260226-2"></script>
+  <script defer src="./js/auth.js"></script>
+  <script defer src="./js/helper_dom.js"></script>
+  <script defer src="./js/helper_sanitize.js"></script>
+  <script defer src="./js/helper_focus.js"></script>
+  <script defer src="./js/signUp.js"></script>
+  <script defer src="./js/helper.js"></script>
   <title>Join - Sign Up</title>
 </head>
 <body>

--- a/summary.html
+++ b/summary.html
@@ -14,38 +14,38 @@
     <link rel="stylesheet" href="./assets/css/mobile-hardening.css">
     <link rel="shortcut icon" href="./assets/img/favicon.png" type="image/png">
 
-    <script src="./js/runtime-fallbacks.js"></script>
-    <script src="./js/ui-event-actions.js"></script>
-    <script src="./js/ui-event-delegation.js"></script>
-    <script src="./js/responsive-navigation.js"></script>
-    <script src="./js/cookiebot-bootstrap.js"></script>
-    <script src="script.js"></script>
-    <script src="./assets/templates/templates_shared.js"></script>
-    <script src="./assets/templates/templates_navigation_auth.js"></script>
-    <script src="./assets/templates/templates_board.js"></script>
-    <script src="./assets/templates/templates_addtask.js"></script>
-    <script src="./js/config.js"></script>
-    <script src="./js/storage_compat_fallbacks.js?v=20260226-2"></script>
-    <script src="./js/storage_error_policy.js?v=20260226-1"></script>
-    <script src="./js/storage_transport.js?v=20260226-1"></script>
-    <script src="./js/storage_firebase_adapter.js?v=20260226-1"></script>
-    <script src="./js/storage_runtime.js?v=20260226-1"></script>
-    <script src="./js/storage.js?v=20260226-2"></script>
-    <script src="./js/auth.js"></script>
-    <script src="./js/contacts.js"></script>
-    <script src="./js/contacts_view.js"></script>
-    <script src="./js/board.js"></script>
-    <script src="./js/board_rendering.js"></script>
-    <script src="./js/board_state.js"></script>
-    <script src="./js/board_media.js"></script>
-    <script src="./js/summary.js"></script>
-    <script src="./js/addTask_dropdown.js"></script>
-    <script src="./js/addTask_keyboard.js"></script>
-    <script src="./js/addTask_form_domain.js"></script>
-    <script src="./js/addTask_ui.js"></script>
-    <script src="./js/addTask.js"></script>
-    <script src="./js/addTask_task_storage.js"></script>
-    <script src="./js/addTask_tasks.js"></script>
+    <script defer src="./js/runtime-fallbacks.js"></script>
+    <script defer src="./js/ui-event-actions.js"></script>
+    <script defer src="./js/ui-event-delegation.js"></script>
+    <script defer src="./js/responsive-navigation.js"></script>
+    <script defer src="./js/cookiebot-bootstrap.js"></script>
+    <script defer src="script.js"></script>
+    <script defer src="./assets/templates/templates_shared.js"></script>
+    <script defer src="./assets/templates/templates_navigation_auth.js"></script>
+    <script defer src="./assets/templates/templates_board.js"></script>
+    <script defer src="./assets/templates/templates_addtask.js"></script>
+    <script defer src="./js/config.js"></script>
+    <script defer src="./js/storage_compat_fallbacks.js?v=20260226-2"></script>
+    <script defer src="./js/storage_error_policy.js?v=20260226-1"></script>
+    <script defer src="./js/storage_transport.js?v=20260226-1"></script>
+    <script defer src="./js/storage_firebase_adapter.js?v=20260226-1"></script>
+    <script defer src="./js/storage_runtime.js?v=20260226-1"></script>
+    <script defer src="./js/storage.js?v=20260226-2"></script>
+    <script defer src="./js/auth.js"></script>
+    <script defer src="./js/contacts.js"></script>
+    <script defer src="./js/contacts_view.js"></script>
+    <script defer src="./js/board.js"></script>
+    <script defer src="./js/board_rendering.js"></script>
+    <script defer src="./js/board_state.js"></script>
+    <script defer src="./js/board_media.js"></script>
+    <script defer src="./js/summary.js"></script>
+    <script defer src="./js/addTask_dropdown.js"></script>
+    <script defer src="./js/addTask_keyboard.js"></script>
+    <script defer src="./js/addTask_form_domain.js"></script>
+    <script defer src="./js/addTask_ui.js"></script>
+    <script defer src="./js/addTask.js"></script>
+    <script defer src="./js/addTask_task_storage.js"></script>
+    <script defer src="./js/addTask_tasks.js"></script>
     <title>Join - Summary</title>
 </head>
 


### PR DESCRIPTION
## Summary
- migrate core pages from blocking script execution to defer-based loading
- introduce defer-safe runtime bootstrap in `script.js`
- keep existing page init contracts (`data-init`) stable

## Changes
- add `defer` to script tags on:
  - addTask, board, contacts, summary, index, signUp
  - help, privacy, privacy_external, legal_notice, legal_notice_external
- refactor bootstrap flow in `script.js`:
  - add `bootstrapRuntime()`
  - add `runNamedPageInitializer()` with bounded retry
  - keep DOM-ready initialization behavior intact

## Validation
- `npm run lint:js`
- `npm run lint:file-size`
- verified script tags on core pages have `blocking=0`

Closes #128
