### PR TITLE
refactor(tooling): trim page scripts via dependency manifests

### DIFF
--- a/PAGE_SCRIPT_DEPENDENCIES.md
+++ b/PAGE_SCRIPT_DEPENDENCIES.md
@@ -1,0 +1,149 @@
+# Page Script Dependencies
+
+This document defines the per-page script manifests used in the HTML entry files.
+Goal: keep page runtime dependencies explicit and avoid hidden cross-page coupling.
+
+## Shared Core Runtime
+
+Used on all app pages:
+
+- `./js/runtime-fallbacks.js`
+- `./js/ui-event-actions.js`
+- `./js/ui-event-delegation.js`
+- `./js/responsive-navigation.js`
+- `./js/cookiebot-bootstrap.js`
+- `script.js`
+- `./js/config.js`
+
+## Shared Storage/Auth Runtime
+
+Used on pages that read/write users/tasks:
+
+- `./js/storage_compat_fallbacks.js`
+- `./js/storage_error_policy.js`
+- `./js/storage_transport.js`
+- `./js/storage_firebase_adapter.js`
+- `./js/storage_runtime.js`
+- `./js/storage.js`
+- `./js/auth.js`
+
+## Per-Page Manifests
+
+### `index.html`
+
+- Shared core runtime
+- Shared storage/auth runtime
+- `./js/login.js`
+
+### `signUp.html`
+
+- Shared core runtime
+- Shared storage/auth runtime
+- `./js/helper_dom.js`
+- `./js/helper_sanitize.js`
+- `./js/helper_focus.js`
+- `./js/helper.js`
+- `./js/signUp.js`
+
+### `summary.html`
+
+- Shared core runtime
+- Shared storage/auth runtime
+- `./assets/templates/templates_navigation_auth.js`
+- `./js/summary.js`
+
+### `contacts.html`
+
+- Shared core runtime
+- Shared storage/auth runtime
+- `./js/helper_dom.js`
+- `./js/helper_sanitize.js`
+- `./js/helper_focus.js`
+- `./js/helper.js`
+- `./js/contacts_render.js`
+- `./js/contacts.js`
+- `./js/contacts_view.js`
+- `./js/contact_list.js`
+- `./js/contact_popups_validation.js`
+- `./js/contact_popups_overlay.js`
+- `./js/contact_popups_mutations.js`
+- `./js/contact_popups.js`
+- `./assets/templates/templates_navigation_auth.js`
+
+### `board.html`
+
+- Shared core runtime
+- Shared storage/auth runtime
+- `./js/helper_dom.js`
+- `./js/helper_sanitize.js`
+- `./js/helper_focus.js`
+- `./js/helper.js`
+- `./js/filepicker_media.js`
+- `./js/filepicker.js`
+- `./js/board.js`
+- `./js/board_rendering.js`
+- `./js/board_state.js`
+- `./js/board_media.js`
+- `./js/board_popups.js`
+- `./js/board_drag_and_drop.js`
+- `./js/contacts.js`
+- `./js/contacts_view.js`
+- `./js/addTask_dropdown.js`
+- `./js/addTask_keyboard.js`
+- `./js/addTask_form_domain.js`
+- `./js/addTask_ui.js`
+- `./js/addTask.js`
+- `./js/addTask_task_storage.js`
+- `./js/addTask_tasks.js`
+- `./assets/templates/templates_shared.js`
+- `./assets/templates/templates_navigation_auth.js`
+- `./assets/templates/templates_board.js`
+- `./assets/templates/templates_addtask.js`
+- `https://cdnjs.cloudflare.com/ajax/libs/viewerjs/1.11.7/viewer.min.js`
+
+### `addTask.html`
+
+- Shared core runtime
+- Shared storage/auth runtime
+- `./js/helper_dom.js`
+- `./js/helper_sanitize.js`
+- `./js/helper_focus.js`
+- `./js/helper.js`
+- `./js/addTask_dropdown.js`
+- `./js/addTask_keyboard.js`
+- `./js/addTask_form_domain.js`
+- `./js/addTask_ui.js`
+- `./js/addTask.js`
+- `./js/addTask_task_storage.js`
+- `./js/addTask_tasks.js`
+- `./js/contacts.js`
+- `./js/contacts_view.js`
+- `./js/board.js`
+- `./js/board_rendering.js`
+- `./js/board_state.js`
+- `./js/board_media.js`
+- `./js/board_drag_and_drop.js`
+- `./js/board_popups.js`
+- `./assets/templates/templates_shared.js`
+- `./assets/templates/templates_navigation_auth.js`
+- `./assets/templates/templates_board.js`
+- `./assets/templates/templates_addtask.js`
+- `./js/filepicker_media.js`
+- `./js/filepicker.js`
+- `https://cdnjs.cloudflare.com/ajax/libs/viewerjs/1.11.7/viewer.min.js`
+
+### `help.html`, `privacy.html`, `legal_notice.html`, `privacy_external.html`, `legal_notice_external.html`
+
+- Shared core runtime
+- `./assets/templates/templates_navigation_auth.js`
+- Page script:
+  - `./js/help.js` for `help.html`
+  - `./js/privacy_and_legal.js` for privacy/legal pages
+
+## Maintenance Rule
+
+When adding a new script include to an HTML page:
+
+1. Update this manifest first.
+2. Add the script only to pages that need the feature.
+3. Verify with `npm run lint:js`.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ npm run a11y:report
 - GitHub issue/PR/project/deploy automation: [GITHUB_AUTOMATION.md](./GITHUB_AUTOMATION.md)
 - Accessibility checks: [ACCESSIBILITY_CHECKS.md](./ACCESSIBILITY_CHECKS.md)
 - File-size guardrails: [FILE_SIZE_GUARDRAILS.md](./FILE_SIZE_GUARDRAILS.md)
+- Page script dependency manifest: [PAGE_SCRIPT_DEPENDENCIES.md](./PAGE_SCRIPT_DEPENDENCIES.md)
 - CSS guardrails (Stylelint): [CSS_GUARDRAILS.md](./CSS_GUARDRAILS.md)
 - JSDoc guardrails: [JSDOC_GUARDRAILS.md](./JSDOC_GUARDRAILS.md)
 - UI tokens and breakpoints: [UI_TOKENS.md](./UI_TOKENS.md)

--- a/contacts.html
+++ b/contacts.html
@@ -33,11 +33,6 @@
     <script defer src="./js/helper_sanitize.js"></script>
     <script defer src="./js/helper_focus.js"></script>
     <script defer src="./js/helper.js"></script>
-    <script defer src="./js/addTask_dropdown.js"></script>
-    <script defer src="./js/addTask_keyboard.js"></script>
-    <script defer src="./js/addTask_form_domain.js"></script>
-    <script defer src="./js/addTask_ui.js"></script>
-    <script defer src="./js/addTask.js"></script>
     <script defer src="./js/contacts_render.js"></script>
     <script defer src="./js/contacts.js"></script>
     <script defer src="./js/contacts_view.js"></script>
@@ -46,10 +41,7 @@
     <script defer src="./js/contact_popups_overlay.js"></script>
     <script defer src="./js/contact_popups_mutations.js"></script>
     <script defer src="./js/contact_popups.js"></script>
-    <script defer src="./assets/templates/templates_shared.js"></script>
     <script defer src="./assets/templates/templates_navigation_auth.js"></script>
-    <script defer src="./assets/templates/templates_board.js"></script>
-    <script defer src="./assets/templates/templates_addtask.js"></script>
 
     <title>Join - Contacts</title>
 </head>

--- a/help.html
+++ b/help.html
@@ -21,12 +21,7 @@
     <script defer src="script.js"></script>
     <script defer src="./js/config.js"></script>
     <script defer src="./js/help.js"></script>
-    <script defer src="./js/contacts.js"></script>
-    <script defer src="./js/contacts_view.js"></script>
-    <script defer src="./assets/templates/templates_shared.js"></script>
     <script defer src="./assets/templates/templates_navigation_auth.js"></script>
-    <script defer src="./assets/templates/templates_board.js"></script>
-    <script defer src="./assets/templates/templates_addtask.js"></script>
 
     <title>Join - Help</title>
 </head>

--- a/legal_notice.html
+++ b/legal_notice.html
@@ -25,10 +25,7 @@
     <script defer src="./js/cookiebot-bootstrap.js"></script>
     <script defer src="script.js"></script>
     <script defer src="./js/config.js"></script>
-    <script defer src="./assets/templates/templates_shared.js"></script>
     <script defer src="./assets/templates/templates_navigation_auth.js"></script>
-    <script defer src="./assets/templates/templates_board.js"></script>
-    <script defer src="./assets/templates/templates_addtask.js"></script>
     <script defer src="./js/privacy_and_legal.js"></script>
 
     <title>Join - Legal Notice</title>

--- a/legal_notice_external.html
+++ b/legal_notice_external.html
@@ -27,10 +27,7 @@
     <script defer src="./js/cookiebot-bootstrap.js"></script>
     <script defer src="script.js"></script>
     <script defer src="./js/config.js"></script>
-    <script defer src="./assets/templates/templates_shared.js"></script>
     <script defer src="./assets/templates/templates_navigation_auth.js"></script>
-    <script defer src="./assets/templates/templates_board.js"></script>
-    <script defer src="./assets/templates/templates_addtask.js"></script>
     <script defer src="./js/privacy_and_legal.js"></script>
 
     <title>Join - Legal Notice External</title>

--- a/privacy.html
+++ b/privacy.html
@@ -22,10 +22,7 @@
     <script defer src="./js/cookiebot-bootstrap.js"></script>
     <script defer src="script.js"></script>
     <script defer src="./js/config.js"></script>
-    <script defer src="./assets/templates/templates_shared.js"></script>
     <script defer src="./assets/templates/templates_navigation_auth.js"></script>
-    <script defer src="./assets/templates/templates_board.js"></script>
-    <script defer src="./assets/templates/templates_addtask.js"></script>
     <script defer src="./js/privacy_and_legal.js"></script>
 
     <title>Join - Privacy Policy</title>

--- a/privacy_external.html
+++ b/privacy_external.html
@@ -23,10 +23,7 @@
     <script defer src="./js/cookiebot-bootstrap.js"></script>
     <script defer src="script.js"></script>
     <script defer src="./js/config.js"></script>
-    <script defer src="./assets/templates/templates_shared.js"></script>
     <script defer src="./assets/templates/templates_navigation_auth.js"></script>
-    <script defer src="./assets/templates/templates_board.js"></script>
-    <script defer src="./assets/templates/templates_addtask.js"></script>
     <script defer src="./js/privacy_and_legal.js"></script>
     <title>Join - Privacy Policy External</title>
 </head>

--- a/summary.html
+++ b/summary.html
@@ -20,10 +20,7 @@
     <script defer src="./js/responsive-navigation.js"></script>
     <script defer src="./js/cookiebot-bootstrap.js"></script>
     <script defer src="script.js"></script>
-    <script defer src="./assets/templates/templates_shared.js"></script>
     <script defer src="./assets/templates/templates_navigation_auth.js"></script>
-    <script defer src="./assets/templates/templates_board.js"></script>
-    <script defer src="./assets/templates/templates_addtask.js"></script>
     <script defer src="./js/config.js"></script>
     <script defer src="./js/storage_compat_fallbacks.js?v=20260226-2"></script>
     <script defer src="./js/storage_error_policy.js?v=20260226-1"></script>
@@ -32,20 +29,7 @@
     <script defer src="./js/storage_runtime.js?v=20260226-1"></script>
     <script defer src="./js/storage.js?v=20260226-2"></script>
     <script defer src="./js/auth.js"></script>
-    <script defer src="./js/contacts.js"></script>
-    <script defer src="./js/contacts_view.js"></script>
-    <script defer src="./js/board.js"></script>
-    <script defer src="./js/board_rendering.js"></script>
-    <script defer src="./js/board_state.js"></script>
-    <script defer src="./js/board_media.js"></script>
     <script defer src="./js/summary.js"></script>
-    <script defer src="./js/addTask_dropdown.js"></script>
-    <script defer src="./js/addTask_keyboard.js"></script>
-    <script defer src="./js/addTask_form_domain.js"></script>
-    <script defer src="./js/addTask_ui.js"></script>
-    <script defer src="./js/addTask.js"></script>
-    <script defer src="./js/addTask_task_storage.js"></script>
-    <script defer src="./js/addTask_tasks.js"></script>
     <title>Join - Summary</title>
 </head>
 


### PR DESCRIPTION
## Summary
- define and document per-page script dependency manifests
- remove unused cross-page script includes from contacts, summary, help, privacy, and legal pages
- decouple summary runtime from board/add-task/contacts globals

## What changed
- add `PAGE_SCRIPT_DEPENDENCIES.md` and link it in `README.md`
- trim script includes in:
  - `contacts.html`
  - `summary.html`
  - `help.html`
  - `privacy.html`
  - `privacy_external.html`
  - `legal_notice.html`
  - `legal_notice_external.html`
- refactor `js/summary.js` to load/filter summary task data locally instead of using board/add-task shared runtime

## Validation
- `npm run lint:js`
- `npm run lint:file-size`

Closes #129
