### PR TITLE
security(csp): add baseline CSP for static entry pages

### DIFF
--- a/CSP_BASELINE.md
+++ b/CSP_BASELINE.md
@@ -1,0 +1,60 @@
+# CSP Baseline
+
+This project now ships a baseline Content Security Policy on all static HTML
+entry pages using a `<meta http-equiv="Content-Security-Policy">` tag.
+
+Covered entry pages:
+
+- `index.html`
+- `signUp.html`
+- `summary.html`
+- `board.html`
+- `contacts.html`
+- `addTask.html`
+- `help.html`
+- `privacy.html`
+- `privacy_external.html`
+- `legal_notice.html`
+- `legal_notice_external.html`
+
+## Baseline Policy
+
+```text
+default-src 'self';
+base-uri 'self';
+object-src 'none';
+frame-ancestors 'self';
+form-action 'self';
+script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com;
+style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com;
+img-src 'self' data: blob:;
+font-src 'self' data:;
+connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com;
+frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com;
+worker-src 'self' blob:;
+```
+
+## Why these sources are allowed
+
+- `https://cdnjs.cloudflare.com`: Viewer.js assets used by board/add-task flow.
+- `https://consent.cookiebot.com`, `https://consentcdn.cookiebot.com`: Cookiebot loader and related assets.
+- `https://remote-storage.developerakademie.org`: remote storage backend.
+- `https://*.firebasedatabase.app`, `https://*.firebaseio.com`: Firebase Realtime Database access.
+- `data:` / `blob:` in `img-src` and `worker-src`: uploaded image previews and viewer/runtime object URLs.
+
+## Rollout visibility
+
+CSP violations are observable via:
+
+1. Browser DevTools Console (`CSP violation: ...` warning logs).
+2. Native browser CSP warnings/events.
+
+The runtime registers a `securitypolicyviolation` listener in `script.js` to
+surface blocked resources clearly during rollout.
+
+## Migration path to stricter CSP
+
+1. Move inline style attributes to CSS classes.
+2. Remove `'unsafe-inline'` from `style-src`.
+3. Serve CSP via response headers at hosting level (recommended) and add reporting endpoint (`report-to` / `report-uri`) when available.
+4. Periodically review allowed external origins and remove no-longer-used hosts.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ npm run a11y:report
 - Page script dependency manifest: [PAGE_SCRIPT_DEPENDENCIES.md](./PAGE_SCRIPT_DEPENDENCIES.md)
 - CSS guardrails (Stylelint): [CSS_GUARDRAILS.md](./CSS_GUARDRAILS.md)
 - JSDoc guardrails: [JSDOC_GUARDRAILS.md](./JSDOC_GUARDRAILS.md)
+- Content Security Policy baseline: [CSP_BASELINE.md](./CSP_BASELINE.md)
 - UI tokens and breakpoints: [UI_TOKENS.md](./UI_TOKENS.md)
 - Secure rendering / XSS rules: [SECURITY_RENDERING.md](./SECURITY_RENDERING.md)
 - Refactor baseline and roadmap: [REFACTOR_RESEARCH.md](./REFACTOR_RESEARCH.md)

--- a/addTask.html
+++ b/addTask.html
@@ -3,7 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="shortcut icon" href="./assets/img/favicon.png" type="image/png">
+  
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
+<link rel="shortcut icon" href="./assets/img/favicon.png" type="image/png">
   
   <!-- Stylesheets -->
   <link rel="stylesheet" href="style.css">

--- a/board.html
+++ b/board.html
@@ -4,7 +4,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="shortcut icon" href="./assets/img/favicon.png" type="image/png">
+    
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
+<link rel="shortcut icon" href="./assets/img/favicon.png" type="image/png">
 
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="./assets/css/ui-tokens.css">

--- a/contacts.html
+++ b/contacts.html
@@ -4,7 +4,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="shortcut icon" href="./assets/img/favicon.png" type="image/png">
+    
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
+<link rel="shortcut icon" href="./assets/img/favicon.png" type="image/png">
 
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="./assets/css/ui-tokens.css">

--- a/help.html
+++ b/help.html
@@ -4,7 +4,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="shortcut icon" href="./assets/img/favicon.png" type="image/png">
+    
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
+<link rel="shortcut icon" href="./assets/img/favicon.png" type="image/png">
 
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="./assets/css/ui-tokens.css">

--- a/index.html
+++ b/index.html
@@ -4,7 +4,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="shortcut icon" href="./assets/img/favicon.png" type="image/png">
+    
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
+<link rel="shortcut icon" href="./assets/img/favicon.png" type="image/png">
 
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="./assets/css/ui-tokens.css">

--- a/legal_notice.html
+++ b/legal_notice.html
@@ -5,7 +5,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link rel="stylesheet" href="style.css">
+    
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
+<link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="./assets/css/ui-tokens.css">
     <link rel="stylesheet" href="./assets/css/accessibility.css">
     <link rel="stylesheet" href="assets/css/header.css" />

--- a/legal_notice_external.html
+++ b/legal_notice_external.html
@@ -5,7 +5,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link rel="stylesheet" href="style.css">
+    
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
+<link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="./assets/css/ui-tokens.css">
     <link rel="stylesheet" href="./assets/css/accessibility.css">
     <link rel="stylesheet" href="assets/css/header.css" />

--- a/privacy.html
+++ b/privacy.html
@@ -4,7 +4,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="style.css">
+    
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
+<link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="./assets/css/ui-tokens.css">
     <link rel="stylesheet" href="./assets/css/accessibility.css">
     <link rel="stylesheet" href="assets/css/header.css" />

--- a/privacy_external.html
+++ b/privacy_external.html
@@ -4,7 +4,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="style.css">
+    
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
+<link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="./assets/css/ui-tokens.css">
     <link rel="stylesheet" href="./assets/css/accessibility.css">
     <link rel="stylesheet" href="assets/css/header.css" />

--- a/script.js
+++ b/script.js
@@ -15,7 +15,27 @@ function bootstrapRuntime() {
 	initializeLegacyRuntimeFallbacks();
 	initializeCookiebot();
 	initializeUiEventDelegation();
+	initializeCspViolationLogging();
 	initializePageOnDomReady();
+}
+
+/**
+ * Registers a CSP violation listener so blocked resources are visible during rollout.
+ * Listener is registered once per page runtime.
+ *
+ * @returns {void}
+ */
+function initializeCspViolationLogging() {
+	if (window.__joinCspViolationLoggingRegistered === true) {
+		return;
+	}
+
+	window.__joinCspViolationLoggingRegistered = true;
+	document.addEventListener("securitypolicyviolation", (event) => {
+		console.warn(
+			`CSP violation: directive=${event.effectiveDirective} blocked=${event.blockedURI || "inline"} source=${event.sourceFile || "n/a"}`
+		);
+	});
 }
 
 /**

--- a/signUp.html
+++ b/signUp.html
@@ -3,7 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="shortcut icon" href="./assets/img/favicon.png" type="image/png">
+  
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
+<link rel="shortcut icon" href="./assets/img/favicon.png" type="image/png">
   <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="./assets/css/ui-tokens.css">
   <link rel="stylesheet" href="./assets/css/accessibility.css">

--- a/summary.html
+++ b/summary.html
@@ -4,7 +4,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="style.css">
+    
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
+<link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="./assets/css/ui-tokens.css">
     <link rel="stylesheet" href="./assets/css/accessibility.css">
     <link rel="stylesheet" href="assets/css/header.css" />


### PR DESCRIPTION
## Summary
- add a baseline Content Security Policy (CSP) to all static HTML entry pages
- allow only required external origins (Cookiebot + Viewer CDN + storage backends)
- add rollout visibility via CSP violation logging and document hardening path

## Changes
- add CSP meta policy to all entry pages:
  - `index.html`
  - `signUp.html`
  - `summary.html`
  - `board.html`
  - `contacts.html`
  - `addTask.html`
  - `help.html`
  - `privacy.html`
  - `privacy_external.html`
  - `legal_notice.html`
  - `legal_notice_external.html`
- register `securitypolicyviolation` logging in `script.js`
- add `CSP_BASELINE.md` with:
  - baseline policy
  - allowed-origin rationale
  - rollout observability guidance
  - migration path to stricter CSP
- link CSP docs in `README.md`

## Validation
- `npm run lint:js`
- `npm run lint:file-size`

Closes #130
