### PR TITLE
fix(csp): remove frame-ancestors from meta CSP

### DIFF
--- a/CSP_BASELINE.md
+++ b/CSP_BASELINE.md
@@ -3,6 +3,11 @@
 This project now ships a baseline Content Security Policy on all static HTML
 entry pages using a `<meta http-equiv="Content-Security-Policy">` tag.
 
+Important limitation:
+
+- `frame-ancestors` is ignored in CSP `<meta>` tags by browsers.
+- If clickjacking protection is required, set `frame-ancestors` via HTTP response header.
+
 Covered entry pages:
 
 - `index.html`
@@ -23,7 +28,6 @@ Covered entry pages:
 default-src 'self';
 base-uri 'self';
 object-src 'none';
-frame-ancestors 'self';
 form-action 'self';
 script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com;
 style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com;
@@ -32,6 +36,19 @@ font-src 'self' data:;
 connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com;
 frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com;
 worker-src 'self' blob:;
+```
+
+## Header-only directives
+
+Use server headers for directives not supported in `<meta>` CSP (especially
+`frame-ancestors`).
+
+Apache (`.htaccess`) example:
+
+```apache
+<IfModule mod_headers.c>
+  Header always set Content-Security-Policy "frame-ancestors 'self'"
+</IfModule>
 ```
 
 ## Why these sources are allowed

--- a/addTask.html
+++ b/addTask.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
 <link rel="shortcut icon" href="./assets/img/favicon.png" type="image/png">
   
   <!-- Stylesheets -->

--- a/board.html
+++ b/board.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
 <link rel="shortcut icon" href="./assets/img/favicon.png" type="image/png">
 
     <link rel="stylesheet" href="style.css">

--- a/contacts.html
+++ b/contacts.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
 <link rel="shortcut icon" href="./assets/img/favicon.png" type="image/png">
 
     <link rel="stylesheet" href="style.css">

--- a/help.html
+++ b/help.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
 <link rel="shortcut icon" href="./assets/img/favicon.png" type="image/png">
 
     <link rel="stylesheet" href="style.css">

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
 <link rel="shortcut icon" href="./assets/img/favicon.png" type="image/png">
 
     <link rel="stylesheet" href="style.css">

--- a/legal_notice.html
+++ b/legal_notice.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
 <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="./assets/css/ui-tokens.css">
     <link rel="stylesheet" href="./assets/css/accessibility.css">

--- a/legal_notice_external.html
+++ b/legal_notice_external.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
 <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="./assets/css/ui-tokens.css">
     <link rel="stylesheet" href="./assets/css/accessibility.css">

--- a/privacy.html
+++ b/privacy.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
 <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="./assets/css/ui-tokens.css">
     <link rel="stylesheet" href="./assets/css/accessibility.css">

--- a/privacy_external.html
+++ b/privacy_external.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
 <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="./assets/css/ui-tokens.css">
     <link rel="stylesheet" href="./assets/css/accessibility.css">

--- a/signUp.html
+++ b/signUp.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
 <link rel="shortcut icon" href="./assets/img/favicon.png" type="image/png">
   <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="./assets/css/ui-tokens.css">

--- a/summary.html
+++ b/summary.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; form-action 'self'; script-src 'self' https://cdnjs.cloudflare.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://remote-storage.developerakademie.org https://*.firebasedatabase.app https://*.firebaseio.com https://consent.cookiebot.com https://consentcdn.cookiebot.com; frame-src 'self' https://consent.cookiebot.com https://consentcdn.cookiebot.com; worker-src 'self' blob:;">
 <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="./assets/css/ui-tokens.css">
     <link rel="stylesheet" href="./assets/css/accessibility.css">


### PR DESCRIPTION
## Summary
- follow-up fix for CSP baseline after the original #130 merge
- remove `frame-ancestors` from meta-delivered CSP to eliminate browser warnings
- document that `frame-ancestors` must be set via HTTP response headers

## Root Cause
The directive `frame-ancestors` is ignored when CSP is delivered via `<meta http-equiv="Content-Security-Policy">`.
This caused repeated console warnings in production (including from Cookiebot runtime).

## Changes
- remove `frame-ancestors 'self';` from CSP meta tags on all HTML entry pages
- update `CSP_BASELINE.md`:
  - explain meta CSP limitation
  - add header-based example (`.htaccess`) for `frame-ancestors`

## Result
- no more `frame-ancestors is ignored when delivered via a <meta> element` noise
- baseline CSP remains active for supported directives
- clear path for header-level hardening

Fixes post-merge CSP warning from #130.
