### PR TITLE
fix(security): enforce noopener/noreferrer on _blank links

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -43,6 +43,12 @@ jobs:
           set -euo pipefail
           npm run lint:inline-events
 
+      - name: Guardrail check for target=_blank link rel safety
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run lint:blank-target-rel
+
       - name: Guardrail check for UI breakpoint and spacing token alignment
         shell: bash
         run: |

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ npm run lint
 npm run lint:css
 npm run lint:jsdoc
 npm run lint:file-size
+npm run lint:blank-target-rel
 npm run a11y:audit
 npm run a11y:ci
 npm run a11y:report

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "lint:css": "npx --yes stylelint@16.24.0 \"assets/css/**/*.css\" \"style.css\"",
     "lint:templates": "node scripts/check_duplicate_template_attributes.cjs",
     "lint:inline-events": "node scripts/check_inline_event_handlers.cjs",
+    "lint:blank-target-rel": "node scripts/check_blank_target_rel.cjs",
     "lint:ui-tokens": "node scripts/check_ui_tokens_alignment.cjs",
-    "lint": "npm run lint:templates && npm run lint:inline-events && npm run lint:ui-tokens && npm run lint:css && npm run lint:file-size && npm run lint:jsdoc && npm run lint:js",
+    "lint": "npm run lint:templates && npm run lint:inline-events && npm run lint:blank-target-rel && npm run lint:ui-tokens && npm run lint:css && npm run lint:file-size && npm run lint:jsdoc && npm run lint:js",
     "a11y:ci": "npx --yes @lhci/cli autorun --config=./lighthouserc.cjs",
     "a11y:report": "node scripts/summarize_lighthouse_accessibility.cjs",
     "a11y:audit": "node scripts/check_accessibility_baseline.cjs"

--- a/privacy.html
+++ b/privacy.html
@@ -64,7 +64,7 @@
                         use of information in accordance with this Privacy Policy. This Privacy Policy has been created
                         with
                         the help of the
-                        <a href="https://www.termsfeed.com/privacy-policy-generator/" target="_blank">Privacy Policy
+                        <a href="https://www.termsfeed.com/privacy-policy-generator/" target="_blank" rel="noopener noreferrer">Privacy Policy
                             Generator</a>.
                     </p>
                     <h2>Interpretation and Definitions</h2>

--- a/privacy_external.html
+++ b/privacy_external.html
@@ -65,7 +65,7 @@
                         use of information in accordance with this Privacy Policy. This Privacy Policy has been created
                         with
                         the help of the
-                        <a href="https://www.termsfeed.com/privacy-policy-generator/" target="_blank">Privacy Policy
+                        <a href="https://www.termsfeed.com/privacy-policy-generator/" target="_blank" rel="noopener noreferrer">Privacy Policy
                             Generator</a>.
                     </p>
                     <h2>Interpretation and Definitions</h2>

--- a/scripts/check_blank_target_rel.cjs
+++ b/scripts/check_blank_target_rel.cjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const HTML_FILES = fs
+  .readdirSync(process.cwd())
+  .filter((fileName) => fileName.endsWith(".html"))
+  .sort();
+
+const findings = [];
+
+for (const htmlFile of HTML_FILES) {
+  const absolutePath = path.resolve(process.cwd(), htmlFile);
+  const htmlSource = fs.readFileSync(absolutePath, "utf8");
+
+  const anchorTagPattern = /<a\b[^>]*>/gi;
+  let match;
+
+  while ((match = anchorTagPattern.exec(htmlSource)) !== null) {
+    const tag = match[0];
+    const targetValue = readAttributeValue(tag, "target");
+    if (!targetValue || targetValue.toLowerCase() !== "_blank") {
+      continue;
+    }
+
+    const relValue = readAttributeValue(tag, "rel") || "";
+    const relTokens = relValue
+      .toLowerCase()
+      .split(/\s+/)
+      .filter(Boolean);
+    const missingTokens = [];
+
+    if (!relTokens.includes("noopener")) {
+      missingTokens.push("noopener");
+    }
+    if (!relTokens.includes("noreferrer")) {
+      missingTokens.push("noreferrer");
+    }
+
+    if (missingTokens.length === 0) {
+      continue;
+    }
+
+    findings.push({
+      file: htmlFile,
+      line: getLineNumber(htmlSource, match.index),
+      missingTokens,
+      tag,
+    });
+  }
+}
+
+if (findings.length > 0) {
+  console.error(
+    `External-link guardrail failed: ${findings.length} target=\"_blank\" anchor(s) missing rel tokens.`
+  );
+  findings.forEach((finding) => {
+    console.error(
+      `- ${finding.file}:${finding.line} missing [${finding.missingTokens.join(
+        ", "
+      )}] -> ${finding.tag}`
+    );
+  });
+  process.exit(1);
+}
+
+console.log(
+  "External-link guardrail passed: all target=\"_blank\" anchors include rel=\"noopener noreferrer\"."
+);
+
+/**
+ * Returns an HTML attribute value from a tag string.
+ *
+ * @param {string} tagSource - Raw HTML tag source.
+ * @param {string} attributeName - HTML attribute name.
+ * @returns {string|null}
+ */
+function readAttributeValue(tagSource, attributeName) {
+  const pattern = new RegExp(
+    `\\b${attributeName}\\s*=\\s*(?:\"([^\"]*)\"|'([^']*)'|([^\\s>]+))`,
+    "i"
+  );
+  const attributeMatch = tagSource.match(pattern);
+  if (!attributeMatch) {
+    return null;
+  }
+  return attributeMatch[1] || attributeMatch[2] || attributeMatch[3] || "";
+}
+
+/**
+ * Returns the 1-based line number for a string index.
+ *
+ * @param {string} source - Source string.
+ * @param {number} index - Character index.
+ * @returns {number}
+ */
+function getLineNumber(source, index) {
+  return source.slice(0, index).split(/\r?\n/).length;
+}


### PR DESCRIPTION
## Summary
- add missing `rel="noopener noreferrer"` to external privacy links opened with `target="_blank"`
- add a guardrail check to prevent regressions for `_blank` links without safe `rel` tokens

## Changes
- update links in:
  - `privacy.html`
  - `privacy_external.html`
- add `scripts/check_blank_target_rel.cjs`
- add npm script: `lint:blank-target-rel`
- integrate guardrail into PR CI (`.github/workflows/pr-tests.yml`)
- document local command in `README.md`

## Validation
- `npm run lint:blank-target-rel`
- `npm run lint:js`

Closes #131
