### PR TITLE
chore: harden issue triage classifier and add fixture tests

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -66,100 +66,23 @@ jobs:
               }
             }
 
+      - name: Checkout repository for triage classifier
+        uses: actions/checkout@v4
+
       - name: Apply labels from issue content
         uses: actions/github-script@v7
         with:
           script: |
+            const { classifyIssue } = require("./scripts/issue_triage_classifier.cjs");
             const issue = context.payload.issue;
             const issueNumber = issue.number;
-            const title = issue.title || "";
-            const body = issue.body || "";
-            const text = `${title}\n${body}`;
-            const lower = text.toLowerCase();
 
             const existing = new Set(issue.labels.map((l) => l.name));
-            const labels = new Set(["needs-triage", "status: backlog"]);
-
-            const hasTypeLabel = [...existing].some((l) => l.startsWith("type: "));
-            const hasPriorityLabel = [...existing].some((l) => l.startsWith("priority: "));
-            const hasAreaLabel = [...existing].some((l) => l.startsWith("area: "));
-
-            function extractPriority() {
-              let match = title.match(/\[(p[0-3])\]/i);
-              if (match) return match[1].toLowerCase();
-
-              match = body.match(/###\s*Priority[\s\S]*?\b(P[0-3])\b/i);
-              if (match) return match[1].toLowerCase();
-
-              match = text.match(/\b(P[0-3])\b/i);
-              if (match) return match[1].toLowerCase();
-
-              return null;
-            }
-
-            if (!hasPriorityLabel) {
-              const priority = extractPriority();
-              if (priority) labels.add(`priority: ${priority}`);
-            }
-
-            if (!hasTypeLabel) {
-              let typeLabel = null;
-              if (/\[security\]|\bsecurity\b/i.test(title) || /(token|credential|password|auth leak|secret)/i.test(lower)) {
-                typeLabel = "type: security";
-              } else if (/\[bug\]|\bbug\b|\bregression\b/i.test(title)) {
-                typeLabel = "type: bug";
-              } else if (/\[refactor\]|\brefactor\b|\btechnical debt\b/i.test(title)) {
-                typeLabel = "type: refactor";
-              } else if (/\[chore\]|\bchore\b|\bci\b|\bworkflow\b|\bdx\b/i.test(title + " " + body)) {
-                typeLabel = "type: chore";
-              } else if (/\[feature\]|\bfeature\b|\benhancement\b/i.test(title)) {
-                typeLabel = "type: feature";
-              }
-
-              if (typeLabel) labels.add(typeLabel);
-            }
-
-            function setAreaByValue(value) {
-              const normalized = value.toLowerCase();
-              if (normalized.includes("auth")) return "area: auth";
-              if (normalized.includes("board")) return "area: board";
-              if (normalized.includes("contact")) return "area: contacts";
-              if (normalized.includes("summary")) return "area: summary";
-              if (normalized.includes("storage") || normalized.includes("firebase") || normalized.includes("api")) return "area: storage";
-              if (normalized.includes("tool")) return "area: tooling";
-              if (normalized.includes("ui")) return "area: ui";
-              return null;
-            }
-
-            if (!hasAreaLabel) {
-              let areaLabel = null;
-              const areaField = body.match(/###\s*Area\s*\n+([^\n]+)/i);
-              if (areaField) {
-                areaLabel = setAreaByValue(areaField[1].trim());
-              }
-
-              if (!areaLabel) {
-                if (/(login|signup|session|remember me|password|auth)/i.test(lower)) {
-                  areaLabel = "area: auth";
-                } else if (/(board|task|subtask|drag)/i.test(lower)) {
-                  areaLabel = "area: board";
-                } else if (/(contact|contacts)/i.test(lower)) {
-                  areaLabel = "area: contacts";
-                } else if (/(summary|dashboard|greeting)/i.test(lower)) {
-                  areaLabel = "area: summary";
-                } else if (/(firebase|storage|fetch|api|token)/i.test(lower)) {
-                  areaLabel = "area: storage";
-                } else if (/(github action|workflow|ci|lint|pipeline)/i.test(lower)) {
-                  areaLabel = "area: tooling";
-                } else {
-                  areaLabel = "area: ui";
-                }
-              }
-
-              if (areaLabel) labels.add(areaLabel);
-            }
-
-            const toAdd = [...labels].filter((l) => !existing.has(l));
+            const toAdd = classifyIssue({
+              title: issue.title || "",
+              body: issue.body || "",
+              existingLabels: [...existing],
+            });
             if (toAdd.length > 0) {
               await github.rest.issues.addLabels({
                 ...context.repo,

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -49,6 +49,12 @@ jobs:
           set -euo pipefail
           npm run lint:blank-target-rel
 
+      - name: Guardrail check for issue-triage classifier fixtures
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run lint:issue-triage
+
       - name: Guardrail check for UI breakpoint and spacing token alignment
         shell: bash
         run: |

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ npm run lint:css
 npm run lint:jsdoc
 npm run lint:file-size
 npm run lint:blank-target-rel
+npm run lint:issue-triage
 npm run a11y:audit
 npm run a11y:ci
 npm run a11y:report

--- a/package.json
+++ b/package.json
@@ -7,11 +7,12 @@
     "lint:jsdoc:update-baseline": "node scripts/check_jsdoc_coverage.cjs --update-baseline",
     "lint:file-size": "node scripts/check_file_size_guardrail.cjs",
     "lint:css": "npx --yes stylelint@16.24.0 \"assets/css/**/*.css\" \"style.css\"",
+    "lint:issue-triage": "node scripts/test_issue_triage_classifier.cjs",
     "lint:templates": "node scripts/check_duplicate_template_attributes.cjs",
     "lint:inline-events": "node scripts/check_inline_event_handlers.cjs",
     "lint:blank-target-rel": "node scripts/check_blank_target_rel.cjs",
     "lint:ui-tokens": "node scripts/check_ui_tokens_alignment.cjs",
-    "lint": "npm run lint:templates && npm run lint:inline-events && npm run lint:blank-target-rel && npm run lint:ui-tokens && npm run lint:css && npm run lint:file-size && npm run lint:jsdoc && npm run lint:js",
+    "lint": "npm run lint:templates && npm run lint:inline-events && npm run lint:blank-target-rel && npm run lint:issue-triage && npm run lint:ui-tokens && npm run lint:css && npm run lint:file-size && npm run lint:jsdoc && npm run lint:js",
     "a11y:ci": "npx --yes @lhci/cli autorun --config=./lighthouserc.cjs",
     "a11y:report": "node scripts/summarize_lighthouse_accessibility.cjs",
     "a11y:audit": "node scripts/check_accessibility_baseline.cjs"

--- a/scripts/fixtures.issue_triage_classifier.json
+++ b/scripts/fixtures.issue_triage_classifier.json
@@ -1,0 +1,106 @@
+[
+  {
+    "name": "explicit_title_chore_over_security_keywords_in_body",
+    "issue": {
+      "title": "[P2][Chore]: Add docs for password migration",
+      "body": "### Priority\nP2 - Medium\n\n### Area\nUI\n\n### Summary\nDocument password/token handling examples for new contributors.",
+      "existingLabels": []
+    },
+    "expectInclude": [
+      "needs-triage",
+      "status: backlog",
+      "priority: p2",
+      "type: chore",
+      "area: ui"
+    ],
+    "expectExclude": ["type: security", "area: auth"]
+  },
+  {
+    "name": "template_area_preferred_over_body_auth_terms",
+    "issue": {
+      "title": "[P1][Bug]: Edit overlay button clipping",
+      "body": "### Priority\nP1 - High\n\n### Area\nUI\n\n### Summary\nLayout issue in contact edit overlay when login/auth text is present in helper text.",
+      "existingLabels": []
+    },
+    "expectInclude": [
+      "needs-triage",
+      "status: backlog",
+      "priority: p1",
+      "type: bug",
+      "area: ui"
+    ],
+    "expectExclude": ["area: auth"]
+  },
+  {
+    "name": "explicit_security_tag_sets_security_type",
+    "issue": {
+      "title": "[P0][Security]: Prevent stored XSS in comments",
+      "body": "### Priority\nP0 - Critical\n\n### Area\nStorage\n\n### Risk / Impact\nStored XSS.\n\n### Proposed Mitigation\nEscape user content.",
+      "existingLabels": []
+    },
+    "expectInclude": [
+      "priority: p0",
+      "type: security",
+      "area: storage"
+    ],
+    "expectExclude": []
+  },
+  {
+    "name": "refactor_template_without_title_tag",
+    "issue": {
+      "title": "Split board runtime into modules",
+      "body": "### Priority\nP2 - Medium\n\n### Area\nBoard\n\n### Context / Problem\nLarge module.\n\n### Proposed Refactor\nSplit rendering and state.\n",
+      "existingLabels": []
+    },
+    "expectInclude": ["priority: p2", "type: refactor", "area: board"],
+    "expectExclude": []
+  },
+  {
+    "name": "bug_template_without_title_tag",
+    "issue": {
+      "title": "Contact save fails after refresh",
+      "body": "### Priority\nP1 - High\n\n### Area\nContacts\n\n### Summary\nSave fails.\n\n### Steps To Reproduce\n1. Open contacts\n2. Save contact\n",
+      "existingLabels": []
+    },
+    "expectInclude": ["priority: p1", "type: bug", "area: contacts"],
+    "expectExclude": []
+  },
+  {
+    "name": "existing_type_not_overwritten",
+    "issue": {
+      "title": "[P2][Security]: classify me",
+      "body": "### Priority\nP2 - Medium\n\n### Area\nTooling\n\n### Summary\nClassifier maintenance.\n",
+      "existingLabels": ["type: chore"]
+    },
+    "expectInclude": ["priority: p2", "area: tooling"],
+    "expectExclude": ["type: security"]
+  },
+  {
+    "name": "no_default_area_when_unknown",
+    "issue": {
+      "title": "[P3][Chore]: repository housekeeping",
+      "body": "### Priority\nP3 - Low\n\n### Summary\nHousekeeping task.\n",
+      "existingLabels": []
+    },
+    "expectInclude": ["priority: p3", "type: chore"],
+    "expectExclude": [
+      "area: ui",
+      "area: auth",
+      "area: board",
+      "area: contacts",
+      "area: summary",
+      "area: storage",
+      "area: tooling"
+    ]
+  },
+  {
+    "name": "area_from_title_tag",
+    "issue": {
+      "title": "[P2][Bug][Storage]: fetch wrapper options wrong",
+      "body": "### Priority\nP2 - Medium\n\n### Summary\nFetch wrapper uses invalid options.",
+      "existingLabels": []
+    },
+    "expectInclude": ["priority: p2", "type: bug", "area: storage"],
+    "expectExclude": []
+  }
+]

--- a/scripts/issue_triage_classifier.cjs
+++ b/scripts/issue_triage_classifier.cjs
@@ -1,0 +1,354 @@
+#!/usr/bin/env node
+
+"use strict";
+
+const TYPE_LABEL_BY_TAG = Object.freeze({
+  bug: "type: bug",
+  security: "type: security",
+  refactor: "type: refactor",
+  chore: "type: chore",
+  feature: "type: feature",
+  enhancement: "type: feature",
+});
+
+const AREA_LABEL_BY_TAG = Object.freeze({
+  auth: "area: auth",
+  board: "area: board",
+  contacts: "area: contacts",
+  contact: "area: contacts",
+  summary: "area: summary",
+  storage: "area: storage",
+  ui: "area: ui",
+  tooling: "area: tooling",
+  accessibility: "area: ui",
+  a11y: "area: ui",
+});
+
+/**
+ * Classifies labels for an issue based on title/body template fields and
+ * conservative fallback heuristics.
+ *
+ * Rules:
+ * - explicit title tags have highest priority
+ * - template fields (`Priority`, `Area`) are preferred over free-text matching
+ * - broad body keyword matching is intentionally avoided to reduce false positives
+ *
+ * @param {{title?:string, body?:string, existingLabels?:string[]}} issueData - Issue payload subset.
+ * @returns {string[]} Labels to add (already excludes existing labels).
+ */
+function classifyIssue(issueData = {}) {
+  const title = typeof issueData.title === "string" ? issueData.title : "";
+  const body = typeof issueData.body === "string" ? issueData.body : "";
+  const existingLabels = Array.isArray(issueData.existingLabels)
+    ? issueData.existingLabels
+    : [];
+
+  const existingSet = new Set(existingLabels);
+  const labels = new Set(["needs-triage", "status: backlog"]);
+
+  const hasTypeLabel = [...existingSet].some((label) =>
+    label.startsWith("type: ")
+  );
+  const hasPriorityLabel = [...existingSet].some((label) =>
+    label.startsWith("priority: ")
+  );
+  const hasAreaLabel = [...existingSet].some((label) =>
+    label.startsWith("area: ")
+  );
+
+  if (!hasPriorityLabel) {
+    const priority = extractPriority(title, body);
+    if (priority) {
+      labels.add(`priority: ${priority}`);
+    }
+  }
+
+  if (!hasTypeLabel) {
+    const typeLabel = classifyType(title, body);
+    if (typeLabel) {
+      labels.add(typeLabel);
+    }
+  }
+
+  if (!hasAreaLabel) {
+    const areaLabel = classifyArea(title, body);
+    if (areaLabel) {
+      labels.add(areaLabel);
+    }
+  }
+
+  return [...labels].filter((label) => !existingSet.has(label));
+}
+
+/**
+ * Extracts normalized priority token.
+ *
+ * @param {string} title - Issue title.
+ * @param {string} body - Issue body.
+ * @returns {string|null} `p0..p3` or null.
+ */
+function extractPriority(title, body) {
+  const titleMatch = title.match(/\[(p[0-3])\]/i);
+  if (titleMatch) {
+    return titleMatch[1].toLowerCase();
+  }
+
+  const priorityField = extractTemplateFieldValue(body, "Priority");
+  if (priorityField) {
+    const fieldMatch = priorityField.match(/\b(p[0-3])\b/i);
+    if (fieldMatch) {
+      return fieldMatch[1].toLowerCase();
+    }
+  }
+
+  const genericMatch = `${title}\n${body}`.match(/\b(p[0-3])\b/i);
+  if (genericMatch) {
+    return genericMatch[1].toLowerCase();
+  }
+
+  return null;
+}
+
+/**
+ * Resolves issue type label from explicit tags and narrow signals.
+ *
+ * @param {string} title - Issue title.
+ * @param {string} body - Issue body.
+ * @returns {string|null}
+ */
+function classifyType(title, body) {
+  const titleTags = extractBracketTags(title);
+
+  for (const tag of titleTags) {
+    const typeFromTag = TYPE_LABEL_BY_TAG[tag];
+    if (typeFromTag) {
+      return typeFromTag;
+    }
+  }
+
+  if (hasTemplateHeading(body, "Proposed Refactor")) {
+    return "type: refactor";
+  }
+  if (hasTemplateHeading(body, "Steps To Reproduce")) {
+    return "type: bug";
+  }
+  if (
+    hasTemplateHeading(body, "Risk / Impact") &&
+    hasTemplateHeading(body, "Proposed Mitigation")
+  ) {
+    return "type: security";
+  }
+  if (hasTemplateHeading(body, "Engineering Value")) {
+    return "type: chore";
+  }
+
+  const lowerTitle = title.toLowerCase();
+  if (
+    /\b(security|xss|csrf|sqli|sql injection|rce|ssrf|auth bypass|privilege escalation|token leak|credential leak|secret leak)\b/i.test(
+      lowerTitle
+    )
+  ) {
+    return "type: security";
+  }
+  if (/\b(bug|regression|crash|broken|fails?)\b/i.test(lowerTitle)) {
+    return "type: bug";
+  }
+  if (/\b(refactor|cleanup|technical debt)\b/i.test(lowerTitle)) {
+    return "type: refactor";
+  }
+  if (/\b(chore|ci|workflow|tooling|maintenance|docs?)\b/i.test(lowerTitle)) {
+    return "type: chore";
+  }
+  if (/\b(feature|enhancement)\b/i.test(lowerTitle)) {
+    return "type: feature";
+  }
+
+  return null;
+}
+
+/**
+ * Resolves issue area label from template fields and title-focused signals.
+ *
+ * @param {string} title - Issue title.
+ * @param {string} body - Issue body.
+ * @returns {string|null}
+ */
+function classifyArea(title, body) {
+  const areaFieldValue = extractTemplateFieldValue(body, "Area");
+  if (areaFieldValue) {
+    const areaFromField = mapAreaValue(areaFieldValue);
+    if (areaFromField) {
+      return areaFromField;
+    }
+  }
+
+  const titleTags = extractBracketTags(title);
+  for (const tag of titleTags) {
+    const areaFromTag = AREA_LABEL_BY_TAG[tag];
+    if (areaFromTag) {
+      return areaFromTag;
+    }
+  }
+
+  const lowerTitle = title.toLowerCase();
+  if (/\b(auth|login|signup|session|remember me)\b/i.test(lowerTitle)) {
+    return "area: auth";
+  }
+  if (/\b(board|kanban|subtask|drag\/drop|drag)\b/i.test(lowerTitle)) {
+    return "area: board";
+  }
+  if (/\b(contacts?)\b/i.test(lowerTitle)) {
+    return "area: contacts";
+  }
+  if (/\b(summary|dashboard|greeting)\b/i.test(lowerTitle)) {
+    return "area: summary";
+  }
+  if (/\b(storage|firebase|database|api|fetch)\b/i.test(lowerTitle)) {
+    return "area: storage";
+  }
+  if (/\b(tooling|workflow|ci|pipeline|lint|github)\b/i.test(lowerTitle)) {
+    return "area: tooling";
+  }
+  if (/\b(ui|css|layout|responsive|accessibility|a11y|ux)\b/i.test(lowerTitle)) {
+    return "area: ui";
+  }
+
+  return null;
+}
+
+/**
+ * Extracts value lines below a markdown `### <label>` heading.
+ *
+ * @param {string} body - Issue markdown body.
+ * @param {string} fieldName - Heading label.
+ * @returns {string|null}
+ */
+function extractTemplateFieldValue(body, fieldName) {
+  if (typeof body !== "string" || body.trim() === "") {
+    return null;
+  }
+
+  const lines = body.split(/\r?\n/);
+  const headingRegex = new RegExp(`^###\\s*${escapeRegExp(fieldName)}\\s*$`, "i");
+
+  for (let index = 0; index < lines.length; index++) {
+    if (!headingRegex.test(lines[index].trim())) {
+      continue;
+    }
+
+    const valueLines = [];
+    for (let cursor = index + 1; cursor < lines.length; cursor++) {
+      const line = lines[cursor];
+      const trimmed = line.trim();
+
+      if (/^###\s+/.test(trimmed)) {
+        break;
+      }
+      if (!trimmed || /^_?no response_?$/i.test(trimmed)) {
+        continue;
+      }
+
+      valueLines.push(trimmed.replace(/^-+\s*/, ""));
+    }
+
+    if (valueLines.length > 0) {
+      return valueLines.join(" ").trim();
+    }
+
+    return null;
+  }
+
+  return null;
+}
+
+/**
+ * Checks whether a markdown heading exists.
+ *
+ * @param {string} body - Issue markdown body.
+ * @param {string} heading - Heading text.
+ * @returns {boolean}
+ */
+function hasTemplateHeading(body, heading) {
+  if (typeof body !== "string" || body.trim() === "") {
+    return false;
+  }
+  const headingRegex = new RegExp(`^###\\s*${escapeRegExp(heading)}\\s*$`, "im");
+  return headingRegex.test(body);
+}
+
+/**
+ * Converts a free-form area value to area label.
+ *
+ * @param {string} value - Area field value.
+ * @returns {string|null}
+ */
+function mapAreaValue(value) {
+  const normalized = value.toLowerCase();
+
+  if (normalized.includes("auth")) return "area: auth";
+  if (normalized.includes("board")) return "area: board";
+  if (normalized.includes("contact")) return "area: contacts";
+  if (normalized.includes("summary")) return "area: summary";
+  if (
+    normalized.includes("storage") ||
+    normalized.includes("firebase") ||
+    normalized.includes("api")
+  ) {
+    return "area: storage";
+  }
+  if (
+    normalized.includes("tool") ||
+    normalized.includes("ci") ||
+    normalized.includes("workflow")
+  ) {
+    return "area: tooling";
+  }
+  if (
+    normalized.includes("ui") ||
+    normalized.includes("css") ||
+    normalized.includes("accessibility") ||
+    normalized.includes("a11y")
+  ) {
+    return "area: ui";
+  }
+
+  return null;
+}
+
+/**
+ * Extracts lowercased bracket tags from title (e.g. [P1][Bug][UI]).
+ *
+ * @param {string} title - Issue title.
+ * @returns {string[]}
+ */
+function extractBracketTags(title) {
+  if (typeof title !== "string" || title.trim() === "") {
+    return [];
+  }
+
+  const tags = [];
+  const pattern = /\[([^\]]+)\]/g;
+  let match;
+  while ((match = pattern.exec(title)) !== null) {
+    tags.push(match[1].trim().toLowerCase());
+  }
+  return tags;
+}
+
+/**
+ * Escapes regex metacharacters.
+ *
+ * @param {string} value - Raw string.
+ * @returns {string}
+ */
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+module.exports = {
+  classifyIssue,
+  classifyType,
+  classifyArea,
+  extractPriority,
+  extractTemplateFieldValue,
+};

--- a/scripts/test_issue_triage_classifier.cjs
+++ b/scripts/test_issue_triage_classifier.cjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { classifyIssue } = require("./issue_triage_classifier.cjs");
+
+const fixturesPath = path.resolve(
+  __dirname,
+  "fixtures.issue_triage_classifier.json"
+);
+const fixtures = JSON.parse(fs.readFileSync(fixturesPath, "utf8"));
+
+const failures = [];
+
+for (const fixture of fixtures) {
+  const issue = fixture.issue || {};
+  const actualLabels = classifyIssue(issue);
+  const actualSet = new Set(actualLabels);
+
+  const expectedIncludes = Array.isArray(fixture.expectInclude)
+    ? fixture.expectInclude
+    : [];
+  const expectedExcludes = Array.isArray(fixture.expectExclude)
+    ? fixture.expectExclude
+    : [];
+
+  const missing = expectedIncludes.filter((label) => !actualSet.has(label));
+  const unexpected = expectedExcludes.filter((label) => actualSet.has(label));
+
+  if (missing.length === 0 && unexpected.length === 0) {
+    console.log(`PASS: ${fixture.name}`);
+    continue;
+  }
+
+  failures.push({
+    name: fixture.name,
+    missing,
+    unexpected,
+    actual: actualLabels,
+  });
+}
+
+if (failures.length > 0) {
+  console.error(
+    `Issue triage classifier fixture tests failed (${failures.length}).`
+  );
+  failures.forEach((failure) => {
+    console.error(`- ${failure.name}`);
+    if (failure.missing.length > 0) {
+      console.error(`  missing labels: ${failure.missing.join(", ")}`);
+    }
+    if (failure.unexpected.length > 0) {
+      console.error(`  unexpected labels: ${failure.unexpected.join(", ")}`);
+    }
+    console.error(`  actual labels: ${failure.actual.join(", ")}`);
+  });
+  process.exit(1);
+}
+
+console.log(
+  `Issue triage classifier fixture tests passed (${fixtures.length} fixtures).`
+);


### PR DESCRIPTION
## Summary
This PR fixes issue triage misclassifications by replacing broad inline regex heuristics with a dedicated classifier module and fixture-based tests.

Closes #132

## What changed
- Added `scripts/issue_triage_classifier.cjs`
- Updated `.github/workflows/issue-triage.yml` to use the shared classifier
- Added fixture set: `scripts/fixtures.issue_triage_classifier.json`
- Added test runner: `scripts/test_issue_triage_classifier.cjs`
- Added npm script: `lint:issue-triage`
- Added PR check step in `.github/workflows/pr-tests.yml`
- Documented local command in `README.md`

## Behavior improvements
- Explicit title tags like `[Bug]`, `[Refactor]`, `[Chore]`, `[Security]` are now highest priority
- Template fields (`Priority`, `Area`) are preferred over broad body keyword matching
- Security and area fallback heuristics are narrower to reduce false positives
- No forced default `area: ui` when area cannot be determined

## Validation
- `npm run lint:issue-triage` ✅
- `npm run lint:js` ✅

## Risk / rollback
- Low risk: logic is isolated in one classifier file and covered by fixtures
- Rollback path: revert this PR to restore previous workflow behavior
