### PR TITLE
chore(deps): introduce Dependabot for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 5
+    labels:
+      - "type: chore"
+      - "area: tooling"
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:15"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 5
+    labels:
+      - "type: chore"
+      - "area: tooling"
+    commit-message:
+      prefix: "chore(deps)"

--- a/GITHUB_AUTOMATION.md
+++ b/GITHUB_AUTOMATION.md
@@ -69,6 +69,23 @@ Required:
 - Add/update dependencies with explicit versions (`npm install <pkg>@<version> ...`) so version intent is reviewable in PRs.
 - Dependency updates must include both `package.json` and `package-lock.json` changes in the same PR.
 
+## Dependency automation (Dependabot)
+
+- File: `.github/dependabot.yml`
+- Ecosystems:
+  - `npm` (root package)
+  - `github-actions` (workflow actions)
+- Schedule: weekly
+- Dependabot PRs are labeled as `type: chore` and `area: tooling`.
+
+### Review and merge checklist for Dependabot PRs
+
+1. Confirm PR scope is dependency-only (no unrelated application code changes).
+2. For npm updates, verify `package.json` and `package-lock.json` are both present in the diff.
+3. Run PR checks and merge only when CI is green.
+4. For GitHub Actions updates, keep actions pinned to full commit SHAs (no fallback to floating tags like `@v4`).
+5. If a major update changes behavior or CI stability, split/hold that PR and handle it in a dedicated follow-up ticket.
+
 ### 4) Deploy on main
 
 - File: `.github/workflows/deploy-on-main.yml`


### PR DESCRIPTION
## Summary
Introduces Dependabot automation for npm and GitHub Actions to keep dependency updates small, regular, and reviewable.

## Changes
- Added `.github/dependabot.yml` with two update ecosystems:
  - `npm` (root `package.json`)
  - `github-actions` (workflow dependencies)
- Configured weekly schedules (Europe/Berlin)
- Limited open Dependabot PRs to `5`
- Added labels for update PRs:
  - `type: chore`
  - `area: tooling`
- Added commit message prefix:
  - `chore(deps)`
- Updated `GITHUB_AUTOMATION.md` with:
  - Dependabot setup overview
  - Review/merge checklist
  - Explicit rule to preserve SHA pinning for GitHub Actions

## Why
Manual dependency updates are error-prone and often too large. Dependabot enables frequent, smaller updates with clearer PR metadata and easier reviews.

## Validation
- `dependabot.yml` parsed successfully
- Existing lint/guardrail checks pass locally

## Notes
- Action SHA pinning policy remains unchanged and must still be enforced during Dependabot PR reviews.
- Closes #171
