### PR TITLE
chore(cache): centralize static asset cache-busting version strategy

### DIFF
--- a/.github/workflows/deploy-on-main.yml
+++ b/.github/workflows/deploy-on-main.yml
@@ -121,6 +121,15 @@ jobs:
           console.log("Generated js/config.js for deployment.");
           NODE
 
+      - name: Inject centralized asset version for local JS/CSS references
+        if: ${{ steps.mode.outputs.mode != 'none' }}
+        shell: bash
+        env:
+          ASSET_VERSION: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          node scripts/inject_asset_version.cjs --version "${ASSET_VERSION}"
+
       - name: Setup SSH key
         if: ${{ steps.mode.outputs.mode == 'ssh' }}
         uses: webfactory/ssh-agent@dc588b651fe13675774614f8e6a936a468676387 # v0.9.0

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -63,6 +63,27 @@ Optional:
 - `JOIN_APP_STORAGE_URL` (default: `https://remote-storage.developerakademie.org/item`)
 - `JOIN_APP_COOKIEBOT_BLOCKING_MODE` (default: `auto`)
 
+## Centralized asset cache-busting
+
+To keep cache invalidation predictable, deploy now uses one central asset version source:
+
+- Source of truth: `github.sha` from the current deploy run
+- Injection step: `node scripts/inject_asset_version.cjs --version "${ASSET_VERSION}"`
+- Scope: local `.js` and `.css` references in root `*.html` files
+
+This means:
+
+- No manual `?v=...` updates in individual HTML files for releases
+- A single deploy applies one consistent asset version across pages
+- Existing query params are preserved, and `v` is refreshed centrally
+
+### Release workflow
+
+1. Merge changes to `main`.
+2. Deploy workflow runs automatically.
+3. Workflow generates runtime config and injects centralized asset version.
+4. Uploaded HTML files reference the new versioned local assets consistently.
+
 ## What gets deployed
 
 The workflow excludes:

--- a/GITHUB_AUTOMATION.md
+++ b/GITHUB_AUTOMATION.md
@@ -94,6 +94,14 @@ Required:
   - SSH + rsync
   - FTPS primary with FTP fallback
 - Also generates `js/config.js` at deploy-time from repository secrets.
+- Also injects centralized cache-busting version for local JS/CSS assets from one source (`github.sha`).
+
+### Asset cache-busting strategy
+
+- Source of truth: deploy-time `ASSET_VERSION` (derived from `github.sha`).
+- Injector script: `scripts/inject_asset_version.cjs`.
+- Target scope: local `.js`/`.css` references in root `*.html` files.
+- Expected workflow: do not manually bump `?v=...` in page files; deploy applies versioning consistently.
 
 ## Setup checklist
 

--- a/addTask.html
+++ b/addTask.html
@@ -34,12 +34,12 @@
   <script defer src="js/helper_focus.js"></script>
   <script defer src="js/helper.js"></script>
   <script defer src="js/config.js"></script>
-  <script defer src="js/storage_compat_fallbacks.js?v=20260226-2"></script>
-  <script defer src="js/storage_error_policy.js?v=20260226-1"></script>
-  <script defer src="js/storage_transport.js?v=20260226-1"></script>
-  <script defer src="js/storage_firebase_adapter.js?v=20260226-1"></script>
-  <script defer src="js/storage_runtime.js?v=20260226-1"></script>
-  <script defer src="js/storage.js?v=20260226-2"></script>
+  <script defer src="js/storage_compat_fallbacks.js"></script>
+  <script defer src="js/storage_error_policy.js"></script>
+  <script defer src="js/storage_transport.js"></script>
+  <script defer src="js/storage_firebase_adapter.js"></script>
+  <script defer src="js/storage_runtime.js"></script>
+  <script defer src="js/storage.js"></script>
   <script defer src="js/auth.js"></script>
   <script defer src="js/addTask_dropdown.js"></script>
   <script defer src="js/addTask_keyboard.js"></script>

--- a/board.html
+++ b/board.html
@@ -44,12 +44,12 @@
     <script defer src="./js/addTask_task_storage.js"></script>
     <script defer src="./js/addTask_tasks.js"></script>
     <script defer src="./js/config.js"></script>
-    <script defer src="./js/storage_compat_fallbacks.js?v=20260226-2"></script>
-    <script defer src="./js/storage_error_policy.js?v=20260226-1"></script>
-    <script defer src="./js/storage_transport.js?v=20260226-1"></script>
-    <script defer src="./js/storage_firebase_adapter.js?v=20260226-1"></script>
-    <script defer src="./js/storage_runtime.js?v=20260226-1"></script>
-    <script defer src="./js/storage.js?v=20260226-2"></script>
+    <script defer src="./js/storage_compat_fallbacks.js"></script>
+    <script defer src="./js/storage_error_policy.js"></script>
+    <script defer src="./js/storage_transport.js"></script>
+    <script defer src="./js/storage_firebase_adapter.js"></script>
+    <script defer src="./js/storage_runtime.js"></script>
+    <script defer src="./js/storage.js"></script>
     <script defer src="./js/auth.js"></script>
     <script defer src="./js/helper_dom.js"></script>
     <script defer src="./js/helper_sanitize.js"></script>

--- a/contacts.html
+++ b/contacts.html
@@ -24,12 +24,12 @@
     <script defer src="./js/cookiebot-bootstrap.js"></script>
     <script defer src="script.js"></script>
     <script defer src="./js/config.js"></script>
-    <script defer src="./js/storage_compat_fallbacks.js?v=20260226-2"></script>
-    <script defer src="./js/storage_error_policy.js?v=20260226-1"></script>
-    <script defer src="./js/storage_transport.js?v=20260226-1"></script>
-    <script defer src="./js/storage_firebase_adapter.js?v=20260226-1"></script>
-    <script defer src="./js/storage_runtime.js?v=20260226-1"></script>
-    <script defer src="./js/storage.js?v=20260226-2"></script>
+    <script defer src="./js/storage_compat_fallbacks.js"></script>
+    <script defer src="./js/storage_error_policy.js"></script>
+    <script defer src="./js/storage_transport.js"></script>
+    <script defer src="./js/storage_firebase_adapter.js"></script>
+    <script defer src="./js/storage_runtime.js"></script>
+    <script defer src="./js/storage.js"></script>
     <script defer src="./js/auth.js"></script>
     <script defer src="./js/helper_dom.js"></script>
     <script defer src="./js/helper_sanitize.js"></script>

--- a/index.html
+++ b/index.html
@@ -23,12 +23,12 @@
     <script defer src="./js/cookiebot-bootstrap.js"></script>
     <script defer src="script.js"></script>
     <script defer src="./js/config.js"></script>
-    <script defer src="./js/storage_compat_fallbacks.js?v=20260226-2"></script>
-    <script defer src="./js/storage_error_policy.js?v=20260226-1"></script>
-    <script defer src="./js/storage_transport.js?v=20260226-1"></script>
-    <script defer src="./js/storage_firebase_adapter.js?v=20260226-1"></script>
-    <script defer src="./js/storage_runtime.js?v=20260226-1"></script>
-    <script defer src="./js/storage.js?v=20260226-2"></script>
+    <script defer src="./js/storage_compat_fallbacks.js"></script>
+    <script defer src="./js/storage_error_policy.js"></script>
+    <script defer src="./js/storage_transport.js"></script>
+    <script defer src="./js/storage_firebase_adapter.js"></script>
+    <script defer src="./js/storage_runtime.js"></script>
+    <script defer src="./js/storage.js"></script>
     <script defer src="./js/auth.js"></script>
     <script defer src="./js/login.js"></script>
 

--- a/scripts/inject_asset_version.cjs
+++ b/scripts/inject_asset_version.cjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const args = process.argv.slice(2);
+let versionArg = null;
+let dryRun = false;
+
+for (let i = 0; i < args.length; i += 1) {
+  const arg = args[i];
+  if (arg === "--dry-run") {
+    dryRun = true;
+    continue;
+  }
+  if (arg === "--version") {
+    versionArg = args[i + 1] || null;
+    i += 1;
+    continue;
+  }
+}
+
+const rawVersion = versionArg || process.env.ASSET_VERSION || "";
+const assetVersion = normalizeAssetVersion(rawVersion);
+
+if (!assetVersion) {
+  console.error(
+    "Missing asset version. Pass --version <value> or set ASSET_VERSION."
+  );
+  process.exit(1);
+}
+
+const rootDir = process.cwd();
+const htmlFiles = fs
+  .readdirSync(rootDir, { withFileTypes: true })
+  .filter((entry) => entry.isFile() && entry.name.toLowerCase().endsWith(".html"))
+  .map((entry) => entry.name)
+  .sort();
+
+let totalRewrites = 0;
+let changedFiles = 0;
+
+for (const htmlFile of htmlFiles) {
+  const htmlPath = path.join(rootDir, htmlFile);
+  const original = fs.readFileSync(htmlPath, "utf8");
+
+  let rewritesInFile = 0;
+  const updated = original.replace(
+    /(<(?:script|link)\b[^>]*?\b(?:src|href)=["'])([^"']+)(["'])/gi,
+    (fullMatch, prefix, url, suffix) => {
+      const rewrittenUrl = withAssetVersion(url, assetVersion);
+      if (rewrittenUrl === url) {
+        return fullMatch;
+      }
+      rewritesInFile += 1;
+      return `${prefix}${rewrittenUrl}${suffix}`;
+    }
+  );
+
+  if (rewritesInFile === 0) {
+    continue;
+  }
+
+  changedFiles += 1;
+  totalRewrites += rewritesInFile;
+
+  if (!dryRun) {
+    fs.writeFileSync(htmlPath, updated, "utf8");
+  }
+
+  console.log(
+    `${dryRun ? "[dry-run] " : ""}${htmlFile}: updated ${rewritesInFile} asset reference(s).`
+  );
+}
+
+console.log(
+  `${dryRun ? "[dry-run] " : ""}Done. Files changed: ${changedFiles}, references updated: ${totalRewrites}, version: ${assetVersion}`
+);
+
+function normalizeAssetVersion(value) {
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  const safe = trimmed.replace(/[^A-Za-z0-9._-]/g, "");
+  if (!safe) {
+    return "";
+  }
+
+  return safe.length > 20 ? safe.slice(0, 20) : safe;
+}
+
+function withAssetVersion(url, version) {
+  if (!isLocalStaticAsset(url)) {
+    return url;
+  }
+
+  const hashIndex = url.indexOf("#");
+  const hashPart = hashIndex >= 0 ? url.slice(hashIndex) : "";
+  const withoutHash = hashIndex >= 0 ? url.slice(0, hashIndex) : url;
+
+  const queryIndex = withoutHash.indexOf("?");
+  const assetPath = queryIndex >= 0 ? withoutHash.slice(0, queryIndex) : withoutHash;
+  const queryPart = queryIndex >= 0 ? withoutHash.slice(queryIndex + 1) : "";
+
+  const params = new URLSearchParams(queryPart);
+  params.delete("v");
+  params.set("v", version);
+
+  return `${assetPath}?${params.toString()}${hashPart}`;
+}
+
+function isLocalStaticAsset(url) {
+  if (typeof url !== "string") {
+    return false;
+  }
+
+  const trimmed = url.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  if (trimmed.startsWith("#")) {
+    return false;
+  }
+
+  if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) {
+    return false;
+  }
+
+  if (trimmed.startsWith("//")) {
+    return false;
+  }
+
+  const pathPart = trimmed.split("?")[0].split("#")[0].toLowerCase();
+  return pathPart.endsWith(".js") || pathPart.endsWith(".css");
+}

--- a/signUp.html
+++ b/signUp.html
@@ -19,12 +19,12 @@
   <script defer src="./js/cookiebot-bootstrap.js"></script>
   <script defer src="script.js"></script>
   <script defer src="./js/config.js"></script>
-  <script defer src="./js/storage_compat_fallbacks.js?v=20260226-2"></script>
-  <script defer src="./js/storage_error_policy.js?v=20260226-1"></script>
-  <script defer src="./js/storage_transport.js?v=20260226-1"></script>
-  <script defer src="./js/storage_firebase_adapter.js?v=20260226-1"></script>
-  <script defer src="./js/storage_runtime.js?v=20260226-1"></script>
-  <script defer src="./js/storage.js?v=20260226-2"></script>
+  <script defer src="./js/storage_compat_fallbacks.js"></script>
+  <script defer src="./js/storage_error_policy.js"></script>
+  <script defer src="./js/storage_transport.js"></script>
+  <script defer src="./js/storage_firebase_adapter.js"></script>
+  <script defer src="./js/storage_runtime.js"></script>
+  <script defer src="./js/storage.js"></script>
   <script defer src="./js/auth.js"></script>
   <script defer src="./js/helper_dom.js"></script>
   <script defer src="./js/helper_sanitize.js"></script>

--- a/summary.html
+++ b/summary.html
@@ -24,12 +24,12 @@
     <script defer src="script.js"></script>
     <script defer src="./assets/templates/templates_navigation_auth.js"></script>
     <script defer src="./js/config.js"></script>
-    <script defer src="./js/storage_compat_fallbacks.js?v=20260226-2"></script>
-    <script defer src="./js/storage_error_policy.js?v=20260226-1"></script>
-    <script defer src="./js/storage_transport.js?v=20260226-1"></script>
-    <script defer src="./js/storage_firebase_adapter.js?v=20260226-1"></script>
-    <script defer src="./js/storage_runtime.js?v=20260226-1"></script>
-    <script defer src="./js/storage.js?v=20260226-2"></script>
+    <script defer src="./js/storage_compat_fallbacks.js"></script>
+    <script defer src="./js/storage_error_policy.js"></script>
+    <script defer src="./js/storage_transport.js"></script>
+    <script defer src="./js/storage_firebase_adapter.js"></script>
+    <script defer src="./js/storage_runtime.js"></script>
+    <script defer src="./js/storage.js"></script>
     <script defer src="./js/auth.js"></script>
     <script defer src="./js/summary.js"></script>
     <title>Join - Summary</title>


### PR DESCRIPTION
## Summary
Centralizes static asset cache-busting to a single deploy-time source of truth.

This removes manual per-file `?v=...` maintenance in HTML and applies one consistent version across local JS/CSS asset references during deploy.

## Changes
- Added new injector script:
  - `scripts/inject_asset_version.cjs`
- Updated deploy workflow:
  - `.github/workflows/deploy-on-main.yml`
  - injects `ASSET_VERSION` from `github.sha`
  - runs `node scripts/inject_asset_version.cjs --version "${ASSET_VERSION}"`
- Removed hard-coded `?v=...` query strings from storage script references in:
  - `index.html`
  - `contacts.html`
  - `board.html`
  - `addTask.html`
  - `summary.html`
  - `signUp.html`
- Documented release/version workflow in:
  - `DEPLOYMENT.md`
  - `GITHUB_AUTOMATION.md`

## Why
Manual cache-busting query strings were duplicated across multiple pages, making releases error-prone and enabling partial cache mismatches.

With centralized deploy-time injection:
- one source of truth (`github.sha`)
- no manual per-page version bumping
- predictable cache invalidation after deploy

## Validation
- `node scripts/inject_asset_version.cjs --version test-asset-v1 --dry-run` passed
- `npm ci` passed
- Passed:
  - `npm run lint:templates`
  - `npm run lint:inline-events`
  - `npm run lint:blank-target-rel`
  - `npm run lint:issue-triage`
  - `npm run lint:ui-tokens`
  - `npm run lint:file-size` (warnings only)
  - `JSDOC_GUARDRAIL_MODE=warn npm run lint:jsdoc`
  - `npm run lint:js`
  - `npm run lint:css`
  - `npm run a11y:audit`
- `npm run a11y:ci` fails locally due to missing Chrome installation in local environment (not related to this change)

## Notes
- The injector only updates local `.js`/`.css` references in root `*.html` files.
- External CDN assets remain untouched.

Closes #135
